### PR TITLE
Feature/gas optimisation in _mintFee

### DIFF
--- a/uniswap-v2-core/contracts/UniswapV2Pair.sol
+++ b/uniswap-v2-core/contracts/UniswapV2Pair.sol
@@ -147,20 +147,21 @@ contract UniswapV2Pair is IUniswapV2Pair, UniswapV2ERC20 {
 
     function _mintFee(uint112 _reserve0, uint112 _reserve1) private returns (bool feeOn) {
         feeOn = platformFee > 0;
-        uint _kLast = kLast;
 
         if (feeOn) {
-            address platformFeeTo = IUniswapV2Factory(factory).platformFeeTo();
-            uint _sqrtNewK = Math.sqrt(uint(_reserve0).mul(_reserve1));
             uint _sqrtOldK = Math.sqrt(kLast); // gas savings
-        
+
             if (_sqrtOldK != 0) {
+                uint _sqrtNewK = Math.sqrt(uint(_reserve0).mul(_reserve1));
+
                 if (_sqrtNewK > _sqrtOldK) {
                     uint _sharesToIssue = _calcFee(_sqrtNewK, _sqrtOldK, platformFee, totalSupply);
+
+                    address platformFeeTo = IUniswapV2Factory(factory).platformFeeTo();
                     if (_sharesToIssue > 0) _mint(platformFeeTo, _sharesToIssue);
                 }
             }
-        } else if (_kLast != 0) {
+        } else if (kLast != 0) {
             kLast = 0;
         }
     }

--- a/uniswap-v2-core/test/UniswapV2Factory.spec.ts
+++ b/uniswap-v2-core/test/UniswapV2Factory.spec.ts
@@ -76,7 +76,7 @@ describe('UniswapV2Factory', () => {
     // Expected init-code (hard coded value is used in dependent modules as a gas optimisation, so also verified here).
     // Note: changing the hard-coded expected init-code value implies you will need to also update the dependency.
     // See dependency @ uniswap-v2-periphery/contracts/libraries/UniswapV2Library.sol
-    expect(initCode, "UniswapV2Pair init-code").to.eq('0xfc21895a2612cf676afb40d6c9fe79b9081a24d853d5de43b7ed068a7d57ffcf')
+    expect(initCode, "UniswapV2Pair init-code").to.eq('0x4131d63b6c526a67156822f613cae3089e63afcc285ea29aa118bc5e6d55810b')
   })
 
   it('createPair:reverse', async () => {

--- a/uniswap-v2-core/test/UniswapV2Factory.spec.ts
+++ b/uniswap-v2-core/test/UniswapV2Factory.spec.ts
@@ -88,7 +88,7 @@ describe('UniswapV2Factory', () => {
     const receipt = await tx.wait()
 
     // Hard-coded gas cost based on current extension
-    expect(receipt.gasUsed).to.eq(3001546)
+    expect(receipt.gasUsed).to.eq(3000546)
   })
 
   it('setPlatformFeeTo', async () => {

--- a/uniswap-v2-core/test/UniswapV2Pair.spec.ts
+++ b/uniswap-v2-core/test/UniswapV2Pair.spec.ts
@@ -340,9 +340,6 @@ describe('UniswapV2Pair', () => {
     const tx = await pair.swap(expectedOutputAmount, 0, wallet.address, '0x', overrides)
     const receipt = await tx.wait()
 
-    // Measure fee-on swap gas cost
-    console.log(receipt.gasUsed.toString())
-
     // Gas price seems to be inconsistent for the swap
     expect(receipt.gasUsed).to.satisfy( function(gas: number) {
       return ((gas==56403) || (gas==97219));
@@ -388,17 +385,22 @@ describe('UniswapV2Pair', () => {
     const tx = await pair.swap(expectedOutputAmount, 0, wallet.address, '0x', overrides)
     const receipt = await tx.wait()
 
-    // Measure fee-on swap gas cost
-    console.log(receipt.gasUsed.toString())
-
-    // Gas price seems to be inconsistent for the swap
+    // Gas price seems to be inconsistent for the swap; most likely due to test framework. (TBC)
+    // Every ~ 1 in 4 runs will see the higher gas cost.
     expect(receipt.gasUsed).to.satisfy( function(gas: number) {
       return ((gas==56403) || (gas==97219));
     })
 
     // Now transfer out the maximum liquidity in order to verify the remaining supply & fees etc
     await pair.transfer(pair.address, expectedLiquidity.sub(MINIMUM_LIQUIDITY))
-    await pair.burn(wallet.address, overrides)
+    const burnTx = await pair.burn(wallet.address, overrides)
+    const burnReceipt = await burnTx.wait()
+
+    // Gas price seems to be inconsistent for the swap; most likely due to test framework. (TBC)
+    // Every ~ 1 in 10 runs will see the higher gas cost.
+    expect(burnReceipt.gasUsed, "Check burn op gas cost (expect 159865 or 119049)").to.satisfy( function(gas: number) {
+      return ((gas==159865) || (gas==119049));
+    })
     
     // Expected fee @ 1/6 or 0.1667% is calculated at 249800449363715 which is a ~0.02% error off the original uniswap.
     // (Original uniswap v2 equivalent ==> 249750499251388)

--- a/uniswap-v2-core/test/UniswapV2Pair.spec.ts
+++ b/uniswap-v2-core/test/UniswapV2Pair.spec.ts
@@ -218,7 +218,6 @@ describe('UniswapV2Pair', () => {
     expect(await token1.balanceOf(wallet.address)).to.eq(totalSupplyToken1.sub(1000))
   })
 
-
   it('price{0,1}CumulativeLast', async () => {
     const token0Amount = expandTo18Decimals(3)
     const token1Amount = expandTo18Decimals(3)
@@ -251,7 +250,6 @@ describe('UniswapV2Pair', () => {
     expect(await pair.price1CumulativeLast(), "Price 1 post sync").to.eq(initialPrice[1].mul(10).add(newPrice[1].mul(10)))
     expect((await pair.getReserves())[2], "Price 0 post sync").to.eq(blockTimestamp + 20)
   })
-
 
   /**
    * calcSwapWithdraw
@@ -293,7 +291,6 @@ describe('UniswapV2Pair', () => {
     return maxTokenToWithdraw 
   } // calcSwapWithdraw
 
-
   /**
    * Test the calcSwapWithdraw function defined above, using pre-existing uniswap test-case mappings.
    */
@@ -315,7 +312,6 @@ describe('UniswapV2Pair', () => {
       expect( calcSwapWithdraw( 30, swapAmount, withdrawTokenBalance, depositTokenBalance ) ).to.eq( expectedOutputAmount )
     })
   })
-
 
   /**
    * Platform Fee off baseline case.
@@ -341,7 +337,16 @@ describe('UniswapV2Pair', () => {
     let expectedOutputAmount: BigNumber = calcSwapWithdraw( lSwapFee, swapAmount, token0Amount, token1Amount )
 
     await token1.transfer(pair.address, swapAmount)
-    await pair.swap(expectedOutputAmount, 0, wallet.address, '0x', overrides)
+    const tx = await pair.swap(expectedOutputAmount, 0, wallet.address, '0x', overrides)
+    const receipt = await tx.wait()
+
+    // Measure fee-on swap gas cost
+    console.log(receipt.gasUsed.toString())
+
+    // Gas price seems to be inconsistent for the swap
+    expect(receipt.gasUsed).to.satisfy( function(gas: number) {
+      return ((gas==56403) || (gas==97219));
+    })
 
     // Drain the liquidity to verify no fee has been extracted on exit
     await pair.transfer(pair.address, expectedLiquidity.sub(MINIMUM_LIQUIDITY))
@@ -380,7 +385,16 @@ describe('UniswapV2Pair', () => {
     expect(await token1.balanceOf(pair.address), "New token1 balance allocated to pair").to.eq(token1Amount.add(swapAmount))
 
     // Perform the swap from token 1 to token 0
-    await pair.swap(expectedOutputAmount, 0, wallet.address, '0x', overrides)
+    const tx = await pair.swap(expectedOutputAmount, 0, wallet.address, '0x', overrides)
+    const receipt = await tx.wait()
+
+    // Measure fee-on swap gas cost
+    console.log(receipt.gasUsed.toString())
+
+    // Gas price seems to be inconsistent for the swap
+    expect(receipt.gasUsed).to.satisfy( function(gas: number) {
+      return ((gas==56403) || (gas==97219));
+    })
 
     // Now transfer out the maximum liquidity in order to verify the remaining supply & fees etc
     await pair.transfer(pair.address, expectedLiquidity.sub(MINIMUM_LIQUIDITY))

--- a/uniswap-v2-periphery/contracts/libraries/UniswapV2Library.sol
+++ b/uniswap-v2-periphery/contracts/libraries/UniswapV2Library.sol
@@ -23,7 +23,7 @@ library UniswapV2Library {
                 keccak256(abi.encodePacked(token0, token1)),
 
                 // Updated hard-coded hash for current UniswapV2Pair
-                hex'fc21895a2612cf676afb40d6c9fe79b9081a24d853d5de43b7ed068a7d57ffcf'
+                hex'4131d63b6c526a67156822f613cae3089e63afcc285ea29aa118bc5e6d55810b'
             ))));
     }
 


### PR DESCRIPTION
Addressing the linked issue for a simple gas-optimisation (of parameter scope); through some experimentation with existing tests, this change found:
- createPair() decreased by 1000gas
- burn() decreased by 195gas

Some inconsistency was also found in gas costs across test runs - this is believed to be due to the testing framework. (TBC)