### PR TITLE
Periphery vvet renaming

### DIFF
--- a/uniswap-v2-periphery/contracts/VexchangeV2Migrator.sol
+++ b/uniswap-v2-periphery/contracts/VexchangeV2Migrator.sol
@@ -17,33 +17,33 @@ contract VexchangeV2Migrator is IVexchangeV2Migrator {
         router = IVexchangeV2Router01(_router);
     }
 
-    // needs to accept ETH from any v1 exchange and the router. ideally this could be enforced, as in the router,
+    // needs to accept VET from any v1 exchange and the router. ideally this could be enforced, as in the router,
     // but it's not possible because it requires a call to the v1 factory, which takes too much gas
     receive() external payable {}
 
-    function migrate(address token, uint amountTokenMin, uint amountETHMin, address to, uint deadline)
+    function migrate(address token, uint amountTokenMin, uint amountVETMin, address to, uint deadline)
         external
         override
     {
         IVexchangeV1Exchange exchangeV1 = IVexchangeV1Exchange(factoryV1.getExchange(token));
         uint liquidityV1 = exchangeV1.balanceOf(msg.sender);
         require(exchangeV1.transferFrom(msg.sender, address(this), liquidityV1), 'TRANSFER_FROM_FAILED');
-        (uint amountETHV1, uint amountTokenV1) = exchangeV1.removeLiquidity(liquidityV1, 1, 1, uint(-1));
+        (uint amountVETV1, uint amountTokenV1) = exchangeV1.removeLiquidity(liquidityV1, 1, 1, uint(-1));
         TransferHelper.safeApprove(token, address(router), amountTokenV1);
-        (uint amountTokenV2, uint amountETHV2,) = router.addLiquidityETH{value: amountETHV1}(
+        (uint amountTokenV2, uint amountVETV2,) = router.addLiquidityVET{value: amountVETV1}(
             token,
             amountTokenV1,
             amountTokenMin,
-            amountETHMin,
+            amountVETMin,
             to,
             deadline
         );
         if (amountTokenV1 > amountTokenV2) {
             TransferHelper.safeApprove(token, address(router), 0); // be a good blockchain citizen, reset allowance to 0
             TransferHelper.safeTransfer(token, msg.sender, amountTokenV1 - amountTokenV2);
-        } else if (amountETHV1 > amountETHV2) {
-            // addLiquidityETH guarantees that all of amountETHV1 or amountTokenV1 will be used, hence this else is safe
-            TransferHelper.safeTransferETH(msg.sender, amountETHV1 - amountETHV2);
+        } else if (amountVETV1 > amountVETV2) {
+            // addLiquidityVET guarantees that all of amountVETV1 or amountTokenV1 will be used, hence this else is safe
+            TransferHelper.safeTransferVET(msg.sender, amountVETV1 - amountVETV2);
         }
     }
 }

--- a/uniswap-v2-periphery/contracts/VexchangeV2Router01.sol
+++ b/uniswap-v2-periphery/contracts/VexchangeV2Router01.sol
@@ -6,24 +6,24 @@ import './ext-lib/TransferHelper.sol';
 import './libraries/VexchangeV2Library.sol';
 import './interfaces/IVexchangeV2Router01.sol';
 import './interfaces/IERC20.sol';
-import './interfaces/IWETH.sol';
+import './interfaces/IVVET.sol';
 
 contract VexchangeV2Router01 is IVexchangeV2Router01 {
     address public immutable override factory;
-    address public immutable override WETH;
+    address public immutable override VVET;
 
     modifier ensure(uint deadline) {
         require(deadline >= block.timestamp, 'VexchangeV2Router: EXPIRED');
         _;
     }
 
-    constructor(address _factory, address _WETH) public {
+    constructor(address _factory, address _VVET) public {
         factory = _factory;
-        WETH = _WETH;
+        VVET = _VVET;
     }
 
     receive() external payable {
-        assert(msg.sender == WETH); // only accept ETH via fallback from the WETH contract
+        assert(msg.sender == VVET); // only accept VET via fallback from the VVET contract
     }
 
     // **** ADD LIQUIDITY ****
@@ -71,28 +71,30 @@ contract VexchangeV2Router01 is IVexchangeV2Router01 {
         TransferHelper.safeTransferFrom(tokenB, msg.sender, pair, amountB);
         liquidity = IVexchangeV2Pair(pair).mint(to);
     }
-    function addLiquidityETH(
+    function addLiquidityVET(
         address token,
         uint amountTokenDesired,
         uint amountTokenMin,
-        uint amountETHMin,
+        uint amountVETMin,
         address to,
         uint deadline
-    ) external override payable ensure(deadline) returns (uint amountToken, uint amountETH, uint liquidity) {
-        (amountToken, amountETH) = _addLiquidity(
+    ) external override payable ensure(deadline) returns (uint amountToken, uint amountVET, uint liquidity) {
+        (amountToken, amountVET) = _addLiquidity(
             token,
-            WETH,
+            VVET,
             amountTokenDesired,
             msg.value,
             amountTokenMin,
-            amountETHMin
+            amountVETMin
         );
-        address pair = VexchangeV2Library.pairFor(factory, token, WETH);
+        address pair = VexchangeV2Library.pairFor(factory, token, VVET);
         TransferHelper.safeTransferFrom(token, msg.sender, pair, amountToken);
-        IWETH(WETH).deposit{value: amountETH}();
-        assert(IWETH(WETH).transfer(pair, amountETH));
+        IVVET(VVET).deposit{value: amountVET}();
+        assert(IVVET(VVET).transfer(pair, amountVET));
         liquidity = IVexchangeV2Pair(pair).mint(to);
-        if (msg.value > amountETH) TransferHelper.safeTransferETH(msg.sender, msg.value - amountETH); // refund dust eth, if any
+
+        // Still applicable for VET? I think yes. msg.value still relevant 
+        if (msg.value > amountVET) TransferHelper.safeTransferVET(msg.sender, msg.value - amountVET); // refund dust vet, if any
     }
 
     // **** REMOVE LIQUIDITY ****
@@ -113,26 +115,26 @@ contract VexchangeV2Router01 is IVexchangeV2Router01 {
         require(amountA >= amountAMin, 'VexchangeV2Router: INSUFFICIENT_A_AMOUNT');
         require(amountB >= amountBMin, 'VexchangeV2Router: INSUFFICIENT_B_AMOUNT');
     }
-    function removeLiquidityETH(
+    function removeLiquidityVET(
         address token,
         uint liquidity,
         uint amountTokenMin,
-        uint amountETHMin,
+        uint amountVETMin,
         address to,
         uint deadline
-    ) public override ensure(deadline) returns (uint amountToken, uint amountETH) {
-        (amountToken, amountETH) = removeLiquidity(
+    ) public override ensure(deadline) returns (uint amountToken, uint amountVET) {
+        (amountToken, amountVET) = removeLiquidity(
             token,
-            WETH,
+            VVET,
             liquidity,
             amountTokenMin,
-            amountETHMin,
+            amountVETMin,
             address(this),
             deadline
         );
         TransferHelper.safeTransfer(token, to, amountToken);
-        IWETH(WETH).withdraw(amountETH);
-        TransferHelper.safeTransferETH(to, amountETH);
+        IVVET(VVET).withdraw(amountVET);
+        TransferHelper.safeTransferVET(to, amountVET);
     }
     function removeLiquidityWithPermit(
         address tokenA,
@@ -149,19 +151,19 @@ contract VexchangeV2Router01 is IVexchangeV2Router01 {
         IVexchangeV2Pair(pair).permit(msg.sender, address(this), value, deadline, v, r, s);
         (amountA, amountB) = removeLiquidity(tokenA, tokenB, liquidity, amountAMin, amountBMin, to, deadline);
     }
-    function removeLiquidityETHWithPermit(
+    function removeLiquidityVETWithPermit(
         address token,
         uint liquidity,
         uint amountTokenMin,
-        uint amountETHMin,
+        uint amountVETMin,
         address to,
         uint deadline,
         bool approveMax, uint8 v, bytes32 r, bytes32 s
-    ) external override returns (uint amountToken, uint amountETH) {
-        address pair = VexchangeV2Library.pairFor(factory, token, WETH);
+    ) external override returns (uint amountToken, uint amountVET) {
+        address pair = VexchangeV2Library.pairFor(factory, token, VVET);
         uint value = approveMax ? uint(-1) : liquidity;
         IVexchangeV2Pair(pair).permit(msg.sender, address(this), value, deadline, v, r, s);
-        (amountToken, amountETH) = removeLiquidityETH(token, liquidity, amountTokenMin, amountETHMin, to, deadline);
+        (amountToken, amountVET) = removeLiquidityVET(token, liquidity, amountTokenMin, amountVETMin, to, deadline);
     }
 
     // **** SWAP ****
@@ -200,62 +202,62 @@ contract VexchangeV2Router01 is IVexchangeV2Router01 {
         TransferHelper.safeTransferFrom(path[0], msg.sender, VexchangeV2Library.pairFor(factory, path[0], path[1]), amounts[0]);
         _swap(amounts, path, to);
     }
-    function swapExactETHForTokens(uint amountOutMin, address[] calldata path, address to, uint deadline)
+    function swapExactVETForTokens(uint amountOutMin, address[] calldata path, address to, uint deadline)
         external
         override
         payable
         ensure(deadline)
         returns (uint[] memory amounts)
     {
-        require(path[0] == WETH, 'VexchangeV2Router: INVALID_PATH');
+        require(path[0] == VVET, 'VexchangeV2Router: INVALID_PATH');
         amounts = VexchangeV2Library.getAmountsOut(factory, msg.value, path);
         require(amounts[amounts.length - 1] >= amountOutMin, 'VexchangeV2Router: INSUFFICIENT_OUTPUT_AMOUNT');
-        IWETH(WETH).deposit{value: amounts[0]}();
-        assert(IWETH(WETH).transfer(VexchangeV2Library.pairFor(factory, path[0], path[1]), amounts[0]));
+        IVVET(VVET).deposit{value: amounts[0]}();
+        assert(IVVET(VVET).transfer(VexchangeV2Library.pairFor(factory, path[0], path[1]), amounts[0]));
         _swap(amounts, path, to);
     }
-    function swapTokensForExactETH(uint amountOut, uint amountInMax, address[] calldata path, address to, uint deadline)
+    function swapTokensForExactVET(uint amountOut, uint amountInMax, address[] calldata path, address to, uint deadline)
         external
         override
         ensure(deadline)
         returns (uint[] memory amounts)
     {
-        require(path[path.length - 1] == WETH, 'VexchangeV2Router: INVALID_PATH');
+        require(path[path.length - 1] == VVET, 'VexchangeV2Router: INVALID_PATH');
         amounts = VexchangeV2Library.getAmountsIn(factory, amountOut, path);
         require(amounts[0] <= amountInMax, 'VexchangeV2Router: EXCESSIVE_INPUT_AMOUNT');
         TransferHelper.safeTransferFrom(path[0], msg.sender, VexchangeV2Library.pairFor(factory, path[0], path[1]), amounts[0]);
         _swap(amounts, path, address(this));
-        IWETH(WETH).withdraw(amounts[amounts.length - 1]);
-        TransferHelper.safeTransferETH(to, amounts[amounts.length - 1]);
+        IVVET(VVET).withdraw(amounts[amounts.length - 1]);
+        TransferHelper.safeTransferVET(to, amounts[amounts.length - 1]);
     }
-    function swapExactTokensForETH(uint amountIn, uint amountOutMin, address[] calldata path, address to, uint deadline)
+    function swapExactTokensForVET(uint amountIn, uint amountOutMin, address[] calldata path, address to, uint deadline)
         external
         override
         ensure(deadline)
         returns (uint[] memory amounts)
     {
-        require(path[path.length - 1] == WETH, 'VexchangeV2Router: INVALID_PATH');
+        require(path[path.length - 1] == VVET, 'VexchangeV2Router: INVALID_PATH');
         amounts = VexchangeV2Library.getAmountsOut(factory, amountIn, path);
         require(amounts[amounts.length - 1] >= amountOutMin, 'VexchangeV2Router: INSUFFICIENT_OUTPUT_AMOUNT');
         TransferHelper.safeTransferFrom(path[0], msg.sender, VexchangeV2Library.pairFor(factory, path[0], path[1]), amounts[0]);
         _swap(amounts, path, address(this));
-        IWETH(WETH).withdraw(amounts[amounts.length - 1]);
-        TransferHelper.safeTransferETH(to, amounts[amounts.length - 1]);
+        IVVET(VVET).withdraw(amounts[amounts.length - 1]);
+        TransferHelper.safeTransferVET(to, amounts[amounts.length - 1]);
     }
-    function swapETHForExactTokens(uint amountOut, address[] calldata path, address to, uint deadline)
+    function swapVETForExactTokens(uint amountOut, address[] calldata path, address to, uint deadline)
         external
         override
         payable
         ensure(deadline)
         returns (uint[] memory amounts)
     {
-        require(path[0] == WETH, 'VexchangeV2Router: INVALID_PATH');
+        require(path[0] == VVET, 'VexchangeV2Router: INVALID_PATH');
         amounts = VexchangeV2Library.getAmountsIn(factory, amountOut, path);
         require(amounts[0] <= msg.value, 'VexchangeV2Router: EXCESSIVE_INPUT_AMOUNT');
-        IWETH(WETH).deposit{value: amounts[0]}();
-        assert(IWETH(WETH).transfer(VexchangeV2Library.pairFor(factory, path[0], path[1]), amounts[0]));
+        IVVET(VVET).deposit{value: amounts[0]}();
+        assert(IVVET(VVET).transfer(VexchangeV2Library.pairFor(factory, path[0], path[1]), amounts[0]));
         _swap(amounts, path, to);
-        if (msg.value > amounts[0]) TransferHelper.safeTransferETH(msg.sender, msg.value - amounts[0]); // refund dust eth, if any
+        if (msg.value > amounts[0]) TransferHelper.safeTransferVET(msg.sender, msg.value - amounts[0]); // refund dust vet, if any
     }
 
     function quote(uint amountA, uint reserveA, uint reserveB) public pure override returns (uint amountB) {

--- a/uniswap-v2-periphery/contracts/VexchangeV2Router01.sol
+++ b/uniswap-v2-periphery/contracts/VexchangeV2Router01.sol
@@ -93,7 +93,6 @@ contract VexchangeV2Router01 is IVexchangeV2Router01 {
         assert(IVVET(VVET).transfer(pair, amountVET));
         liquidity = IVexchangeV2Pair(pair).mint(to);
 
-        // Still applicable for VET? I think yes. msg.value still relevant 
         if (msg.value > amountVET) TransferHelper.safeTransferVET(msg.sender, msg.value - amountVET); // refund dust vet, if any
     }
 

--- a/uniswap-v2-periphery/contracts/VexchangeV2Router02.sol
+++ b/uniswap-v2-periphery/contracts/VexchangeV2Router02.sol
@@ -7,26 +7,26 @@ import './interfaces/IVexchangeV2Router02.sol';
 import './libraries/VexchangeV2Library.sol';
 import './libraries/SafeMath.sol';
 import './interfaces/IERC20.sol';
-import './interfaces/IWETH.sol';
+import './interfaces/IVVET.sol';
 
 contract VexchangeV2Router02 is IVexchangeV2Router02 {
     using SafeMath for uint;
 
     address public immutable override factory;
-    address public immutable override WETH;
+    address public immutable override VVET;
 
     modifier ensure(uint deadline) {
         require(deadline >= block.timestamp, 'VexchangeV2Router: EXPIRED');
         _;
     }
 
-    constructor(address _factory, address _WETH) public {
+    constructor(address _factory, address _VVET) public {
         factory = _factory;
-        WETH = _WETH;
+        VVET = _VVET;
     }
 
     receive() external payable {
-        assert(msg.sender == WETH); // only accept ETH via fallback from the WETH contract
+        assert(msg.sender == VVET); // only accept VET via fallback from the VVET contract
     }
 
     // **** ADD LIQUIDITY ****
@@ -74,29 +74,29 @@ contract VexchangeV2Router02 is IVexchangeV2Router02 {
         TransferHelper.safeTransferFrom(tokenB, msg.sender, pair, amountB);
         liquidity = IVexchangeV2Pair(pair).mint(to);
     }
-    function addLiquidityETH(
+    function addLiquidityVET(
         address token,
         uint amountTokenDesired,
         uint amountTokenMin,
-        uint amountETHMin,
+        uint amountVETMin,
         address to,
         uint deadline
-    ) external virtual override payable ensure(deadline) returns (uint amountToken, uint amountETH, uint liquidity) {
-        (amountToken, amountETH) = _addLiquidity(
+    ) external virtual override payable ensure(deadline) returns (uint amountToken, uint amountVET, uint liquidity) {
+        (amountToken, amountVET) = _addLiquidity(
             token,
-            WETH,
+            VVET,
             amountTokenDesired,
             msg.value,
             amountTokenMin,
-            amountETHMin
+            amountVETMin
         );
-        address pair = VexchangeV2Library.pairFor(factory, token, WETH);
+        address pair = VexchangeV2Library.pairFor(factory, token, VVET);
         TransferHelper.safeTransferFrom(token, msg.sender, pair, amountToken);
-        IWETH(WETH).deposit{value: amountETH}();
-        assert(IWETH(WETH).transfer(pair, amountETH));
+        IVVET(VVET).deposit{value: amountVET}();
+        assert(IVVET(VVET).transfer(pair, amountVET));
         liquidity = IVexchangeV2Pair(pair).mint(to);
         // refund dust eth, if any
-        if (msg.value > amountETH) TransferHelper.safeTransferETH(msg.sender, msg.value - amountETH);
+        if (msg.value > amountVET) TransferHelper.safeTransferVET(msg.sender, msg.value - amountVET);
     }
 
     // **** REMOVE LIQUIDITY ****
@@ -117,26 +117,26 @@ contract VexchangeV2Router02 is IVexchangeV2Router02 {
         require(amountA >= amountAMin, 'VexchangeV2Router: INSUFFICIENT_A_AMOUNT');
         require(amountB >= amountBMin, 'VexchangeV2Router: INSUFFICIENT_B_AMOUNT');
     }
-    function removeLiquidityETH(
+    function removeLiquidityVET(
         address token,
         uint liquidity,
         uint amountTokenMin,
-        uint amountETHMin,
+        uint amountVETMin,
         address to,
         uint deadline
-    ) public virtual override ensure(deadline) returns (uint amountToken, uint amountETH) {
-        (amountToken, amountETH) = removeLiquidity(
+    ) public virtual override ensure(deadline) returns (uint amountToken, uint amountVET) {
+        (amountToken, amountVET) = removeLiquidity(
             token,
-            WETH,
+            VVET,
             liquidity,
             amountTokenMin,
-            amountETHMin,
+            amountVETMin,
             address(this),
             deadline
         );
         TransferHelper.safeTransfer(token, to, amountToken);
-        IWETH(WETH).withdraw(amountETH);
-        TransferHelper.safeTransferETH(to, amountETH);
+        IVVET(VVET).withdraw(amountVET);
+        TransferHelper.safeTransferVET(to, amountVET);
     }
     function removeLiquidityWithPermit(
         address tokenA,
@@ -153,57 +153,57 @@ contract VexchangeV2Router02 is IVexchangeV2Router02 {
         IVexchangeV2Pair(pair).permit(msg.sender, address(this), value, deadline, v, r, s);
         (amountA, amountB) = removeLiquidity(tokenA, tokenB, liquidity, amountAMin, amountBMin, to, deadline);
     }
-    function removeLiquidityETHWithPermit(
+    function removeLiquidityVETWithPermit(
         address token,
         uint liquidity,
         uint amountTokenMin,
-        uint amountETHMin,
+        uint amountVETMin,
         address to,
         uint deadline,
         bool approveMax, uint8 v, bytes32 r, bytes32 s
-    ) external virtual override returns (uint amountToken, uint amountETH) {
-        address pair = VexchangeV2Library.pairFor(factory, token, WETH);
+    ) external virtual override returns (uint amountToken, uint amountVET) {
+        address pair = VexchangeV2Library.pairFor(factory, token, VVET);
         uint value = approveMax ? uint(-1) : liquidity;
         IVexchangeV2Pair(pair).permit(msg.sender, address(this), value, deadline, v, r, s);
-        (amountToken, amountETH) = removeLiquidityETH(token, liquidity, amountTokenMin, amountETHMin, to, deadline);
+        (amountToken, amountVET) = removeLiquidityVET(token, liquidity, amountTokenMin, amountVETMin, to, deadline);
     }
 
     // **** REMOVE LIQUIDITY (supporting fee-on-transfer tokens) ****
-    function removeLiquidityETHSupportingFeeOnTransferTokens(
+    function removeLiquidityVETSupportingFeeOnTransferTokens(
         address token,
         uint liquidity,
         uint amountTokenMin,
-        uint amountETHMin,
+        uint amountVETMin,
         address to,
         uint deadline
-    ) public virtual override ensure(deadline) returns (uint amountETH) {
-        (, amountETH) = removeLiquidity(
+    ) public virtual override ensure(deadline) returns (uint amountVET) {
+        (, amountVET) = removeLiquidity(
             token,
-            WETH,
+            VVET,
             liquidity,
             amountTokenMin,
-            amountETHMin,
+            amountVETMin,
             address(this),
             deadline
         );
         TransferHelper.safeTransfer(token, to, IERC20(token).balanceOf(address(this)));
-        IWETH(WETH).withdraw(amountETH);
-        TransferHelper.safeTransferETH(to, amountETH);
+        IVVET(VVET).withdraw(amountVET);
+        TransferHelper.safeTransferVET(to, amountVET);
     }
-    function removeLiquidityETHWithPermitSupportingFeeOnTransferTokens(
+    function removeLiquidityVETWithPermitSupportingFeeOnTransferTokens(
         address token,
         uint liquidity,
         uint amountTokenMin,
-        uint amountETHMin,
+        uint amountVETMin,
         address to,
         uint deadline,
         bool approveMax, uint8 v, bytes32 r, bytes32 s
-    ) external virtual override returns (uint amountETH) {
-        address pair = VexchangeV2Library.pairFor(factory, token, WETH);
+    ) external virtual override returns (uint amountVET) {
+        address pair = VexchangeV2Library.pairFor(factory, token, VVET);
         uint value = approveMax ? uint(-1) : liquidity;
         IVexchangeV2Pair(pair).permit(msg.sender, address(this), value, deadline, v, r, s);
-        amountETH = removeLiquidityETHSupportingFeeOnTransferTokens(
-            token, liquidity, amountTokenMin, amountETHMin, to, deadline
+        amountVET = removeLiquidityVETSupportingFeeOnTransferTokens(
+            token, liquidity, amountTokenMin, amountVETMin, to, deadline
         );
     }
 
@@ -249,7 +249,7 @@ contract VexchangeV2Router02 is IVexchangeV2Router02 {
         );
         _swap(amounts, path, to);
     }
-    function swapExactETHForTokens(uint amountOutMin, address[] calldata path, address to, uint deadline)
+    function swapExactVETForTokens(uint amountOutMin, address[] calldata path, address to, uint deadline)
         external
         virtual
         override
@@ -257,48 +257,48 @@ contract VexchangeV2Router02 is IVexchangeV2Router02 {
         ensure(deadline)
         returns (uint[] memory amounts)
     {
-        require(path[0] == WETH, 'VexchangeV2Router: INVALID_PATH');
+        require(path[0] == VVET, 'VexchangeV2Router: INVALID_PATH');
         amounts = VexchangeV2Library.getAmountsOut(factory, msg.value, path);
         require(amounts[amounts.length - 1] >= amountOutMin, 'VexchangeV2Router: INSUFFICIENT_OUTPUT_AMOUNT');
-        IWETH(WETH).deposit{value: amounts[0]}();
-        assert(IWETH(WETH).transfer(VexchangeV2Library.pairFor(factory, path[0], path[1]), amounts[0]));
+        IVVET(VVET).deposit{value: amounts[0]}();
+        assert(IVVET(VVET).transfer(VexchangeV2Library.pairFor(factory, path[0], path[1]), amounts[0]));
         _swap(amounts, path, to);
     }
-    function swapTokensForExactETH(uint amountOut, uint amountInMax, address[] calldata path, address to, uint deadline)
+    function swapTokensForExactVET(uint amountOut, uint amountInMax, address[] calldata path, address to, uint deadline)
         external
         virtual
         override
         ensure(deadline)
         returns (uint[] memory amounts)
     {
-        require(path[path.length - 1] == WETH, 'VexchangeV2Router: INVALID_PATH');
+        require(path[path.length - 1] == VVET, 'VexchangeV2Router: INVALID_PATH');
         amounts = VexchangeV2Library.getAmountsIn(factory, amountOut, path);
         require(amounts[0] <= amountInMax, 'VexchangeV2Router: EXCESSIVE_INPUT_AMOUNT');
         TransferHelper.safeTransferFrom(
             path[0], msg.sender, VexchangeV2Library.pairFor(factory, path[0], path[1]), amounts[0]
         );
         _swap(amounts, path, address(this));
-        IWETH(WETH).withdraw(amounts[amounts.length - 1]);
-        TransferHelper.safeTransferETH(to, amounts[amounts.length - 1]);
+        IVVET(VVET).withdraw(amounts[amounts.length - 1]);
+        TransferHelper.safeTransferVET(to, amounts[amounts.length - 1]);
     }
-    function swapExactTokensForETH(uint amountIn, uint amountOutMin, address[] calldata path, address to, uint deadline)
+    function swapExactTokensForVET(uint amountIn, uint amountOutMin, address[] calldata path, address to, uint deadline)
         external
         virtual
         override
         ensure(deadline)
         returns (uint[] memory amounts)
     {
-        require(path[path.length - 1] == WETH, 'VexchangeV2Router: INVALID_PATH');
+        require(path[path.length - 1] == VVET, 'VexchangeV2Router: INVALID_PATH');
         amounts = VexchangeV2Library.getAmountsOut(factory, amountIn, path);
         require(amounts[amounts.length - 1] >= amountOutMin, 'VexchangeV2Router: INSUFFICIENT_OUTPUT_AMOUNT');
         TransferHelper.safeTransferFrom(
             path[0], msg.sender, VexchangeV2Library.pairFor(factory, path[0], path[1]), amounts[0]
         );
         _swap(amounts, path, address(this));
-        IWETH(WETH).withdraw(amounts[amounts.length - 1]);
-        TransferHelper.safeTransferETH(to, amounts[amounts.length - 1]);
+        IVVET(VVET).withdraw(amounts[amounts.length - 1]);
+        TransferHelper.safeTransferVET(to, amounts[amounts.length - 1]);
     }
-    function swapETHForExactTokens(uint amountOut, address[] calldata path, address to, uint deadline)
+    function swapVETForExactTokens(uint amountOut, address[] calldata path, address to, uint deadline)
         external
         virtual
         override
@@ -306,14 +306,14 @@ contract VexchangeV2Router02 is IVexchangeV2Router02 {
         ensure(deadline)
         returns (uint[] memory amounts)
     {
-        require(path[0] == WETH, 'VexchangeV2Router: INVALID_PATH');
+        require(path[0] == VVET, 'VexchangeV2Router: INVALID_PATH');
         amounts = VexchangeV2Library.getAmountsIn(factory, amountOut, path);
         require(amounts[0] <= msg.value, 'VexchangeV2Router: EXCESSIVE_INPUT_AMOUNT');
-        IWETH(WETH).deposit{value: amounts[0]}();
-        assert(IWETH(WETH).transfer(VexchangeV2Library.pairFor(factory, path[0], path[1]), amounts[0]));
+        IVVET(VVET).deposit{value: amounts[0]}();
+        assert(IVVET(VVET).transfer(VexchangeV2Library.pairFor(factory, path[0], path[1]), amounts[0]));
         _swap(amounts, path, to);
         // refund dust eth, if any
-        if (msg.value > amounts[0]) TransferHelper.safeTransferETH(msg.sender, msg.value - amounts[0]);
+        if (msg.value > amounts[0]) TransferHelper.safeTransferVET(msg.sender, msg.value - amounts[0]);
     }
 
     // **** SWAP (supporting fee-on-transfer tokens) ****
@@ -353,7 +353,7 @@ contract VexchangeV2Router02 is IVexchangeV2Router02 {
             'VexchangeV2Router: INSUFFICIENT_OUTPUT_AMOUNT'
         );
     }
-    function swapExactETHForTokensSupportingFeeOnTransferTokens(
+    function swapExactVETForTokensSupportingFeeOnTransferTokens(
         uint amountOutMin,
         address[] calldata path,
         address to,
@@ -365,10 +365,10 @@ contract VexchangeV2Router02 is IVexchangeV2Router02 {
         payable
         ensure(deadline)
     {
-        require(path[0] == WETH, 'VexchangeV2Router: INVALID_PATH');
+        require(path[0] == VVET, 'VexchangeV2Router: INVALID_PATH');
         uint amountIn = msg.value;
-        IWETH(WETH).deposit{value: amountIn}();
-        assert(IWETH(WETH).transfer(VexchangeV2Library.pairFor(factory, path[0], path[1]), amountIn));
+        IVVET(VVET).deposit{value: amountIn}();
+        assert(IVVET(VVET).transfer(VexchangeV2Library.pairFor(factory, path[0], path[1]), amountIn));
         uint balanceBefore = IERC20(path[path.length - 1]).balanceOf(to);
         _swapSupportingFeeOnTransferTokens(path, to);
         require(
@@ -376,7 +376,7 @@ contract VexchangeV2Router02 is IVexchangeV2Router02 {
             'VexchangeV2Router: INSUFFICIENT_OUTPUT_AMOUNT'
         );
     }
-    function swapExactTokensForETHSupportingFeeOnTransferTokens(
+    function swapExactTokensForVETSupportingFeeOnTransferTokens(
         uint amountIn,
         uint amountOutMin,
         address[] calldata path,
@@ -388,15 +388,15 @@ contract VexchangeV2Router02 is IVexchangeV2Router02 {
         override
         ensure(deadline)
     {
-        require(path[path.length - 1] == WETH, 'VexchangeV2Router: INVALID_PATH');
+        require(path[path.length - 1] == VVET, 'VexchangeV2Router: INVALID_PATH');
         TransferHelper.safeTransferFrom(
             path[0], msg.sender, VexchangeV2Library.pairFor(factory, path[0], path[1]), amountIn
         );
         _swapSupportingFeeOnTransferTokens(path, address(this));
-        uint amountOut = IERC20(WETH).balanceOf(address(this));
+        uint amountOut = IERC20(VVET).balanceOf(address(this));
         require(amountOut >= amountOutMin, 'VexchangeV2Router: INSUFFICIENT_OUTPUT_AMOUNT');
-        IWETH(WETH).withdraw(amountOut);
-        TransferHelper.safeTransferETH(to, amountOut);
+        IVVET(VVET).withdraw(amountOut);
+        TransferHelper.safeTransferVET(to, amountOut);
     }
 
     // **** LIBRARY FUNCTIONS ****

--- a/uniswap-v2-periphery/contracts/examples/ExampleFlashSwap.sol
+++ b/uniswap-v2-periphery/contracts/examples/ExampleFlashSwap.sol
@@ -7,24 +7,24 @@ import '../interfaces/V1/IVexchangeV1Factory.sol';
 import '../interfaces/V1/IVexchangeV1Exchange.sol';
 import '../interfaces/IVexchangeV2Router01.sol';
 import '../interfaces/IERC20.sol';
-import '../interfaces/IWETH.sol';
+import '../interfaces/IVVET.sol';
 
 contract ExampleFlashSwap is IVexchangeV2Callee {
     IVexchangeV1Factory immutable factoryV1;
     address immutable factory;
-    IWETH immutable WETH;
+    IVVET immutable VVET;
 
     constructor(address _factory, address _factoryV1, address router) public {
         factoryV1 = IVexchangeV1Factory(_factoryV1);
         factory = _factory;
-        WETH = IWETH(IVexchangeV2Router01(router).WETH());
+        VVET = IVVET(IVexchangeV2Router01(router).VVET());
     }
 
-    // needs to accept ETH from any V1 exchange and WETH. ideally this could be enforced, as in the router,
+    // needs to accept ETH from any V1 exchange and VVET. ideally this could be enforced, as in the router,
     // but it's not possible because it requires a call to the v1 factory, which takes too much gas
     receive() external payable {}
 
-    // gets tokens/WETH via a V2 flash swap, swaps for the ETH/tokens on V1, repays V2, and keeps the rest!
+    // gets tokens/VVET via a V2 flash swap, swaps for the ETH/tokens on V1, repays V2, and keeps the rest!
     function vexchangeV2Call(address sender, uint amount0, uint amount1, bytes calldata data) external override {
         address[] memory path = new address[](2);
         uint amountToken;
@@ -36,12 +36,12 @@ contract ExampleFlashSwap is IVexchangeV2Callee {
         assert(amount0 == 0 || amount1 == 0); // this strategy is unidirectional
         path[0] = amount0 == 0 ? token0 : token1;
         path[1] = amount0 == 0 ? token1 : token0;
-        amountToken = token0 == address(WETH) ? amount1 : amount0;
-        amountETH = token0 == address(WETH) ? amount0 : amount1;
+        amountToken = token0 == address(VVET) ? amount1 : amount0;
+        amountETH = token0 == address(VVET) ? amount0 : amount1;
         }
 
-        assert(path[0] == address(WETH) || path[1] == address(WETH)); // this strategy only works with a V2 WETH pair
-        IERC20 token = IERC20(path[0] == address(WETH) ? path[1] : path[0]);
+        assert(path[0] == address(VVET) || path[1] == address(VVET)); // this strategy only works with a V2 VVET pair
+        IERC20 token = IERC20(path[0] == address(VVET) ? path[1] : path[0]);
         IVexchangeV1Exchange exchangeV1 = IVexchangeV1Exchange(factoryV1.getExchange(address(token))); // get V1 exchange
 
         if (amountToken > 0) {
@@ -50,13 +50,13 @@ contract ExampleFlashSwap is IVexchangeV2Callee {
             uint amountReceived = exchangeV1.tokenToEthSwapInput(amountToken, minETH, uint(-1));
             uint amountRequired = VexchangeV2Library.getAmountsIn(factory, amountToken, path)[0];
             assert(amountReceived > amountRequired); // fail if we didn't get enough ETH back to repay our flash loan
-            WETH.deposit{value: amountRequired}();
-            assert(WETH.transfer(msg.sender, amountRequired)); // return WETH to V2 pair
+            VVET.deposit{value: amountRequired}();
+            assert(VVET.transfer(msg.sender, amountRequired)); // return VVET to V2 pair
             (bool success,) = sender.call{value: amountReceived - amountRequired}(new bytes(0)); // keep the rest! (ETH)
             assert(success);
         } else {
             (uint minTokens) = abi.decode(data, (uint)); // slippage parameter for V1, passed in by caller
-            WETH.withdraw(amountETH);
+            VVET.withdraw(amountETH);
             uint amountReceived = exchangeV1.ethToTokenSwapInput{value: amountETH}(minTokens, uint(-1));
             uint amountRequired = VexchangeV2Library.getAmountsIn(factory, amountETH, path)[0];
             assert(amountReceived > amountRequired); // fail if we didn't get enough tokens back to repay our flash loan

--- a/uniswap-v2-periphery/contracts/ext-lib/TransferHelper.sol
+++ b/uniswap-v2-periphery/contracts/ext-lib/TransferHelper.sol
@@ -2,7 +2,7 @@
 
 pragma solidity >=0.6.0;
 
-// helper methods for interacting with ERC20 tokens and sending ETH that do not consistently return true/false
+// helper methods for interacting with ERC20 tokens and sending VET that do not consistently return true/false
 library TransferHelper {
     function safeApprove(
         address token,
@@ -44,8 +44,8 @@ library TransferHelper {
         );
     }
 
-    function safeTransferETH(address to, uint256 value) internal {
+    function safeTransferVET(address to, uint256 value) internal {
         (bool success, ) = to.call{value: value}(new bytes(0));
-        require(success, 'TransferHelper::safeTransferETH: ETH transfer failed');
+        require(success, 'TransferHelper::safeTransferVET: VET transfer failed');
     }
 }

--- a/uniswap-v2-periphery/contracts/interfaces/IVVET.sol
+++ b/uniswap-v2-periphery/contracts/interfaces/IVVET.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.5.0;
 
-interface IWETH {
+interface IVVET {
     function deposit() external payable;
     function transfer(address to, uint value) external returns (bool);
     function withdraw(uint) external;

--- a/uniswap-v2-periphery/contracts/interfaces/IVexchangeV2Migrator.sol
+++ b/uniswap-v2-periphery/contracts/interfaces/IVexchangeV2Migrator.sol
@@ -1,5 +1,5 @@
 pragma solidity >=0.5.0;
 
 interface IVexchangeV2Migrator {
-    function migrate(address token, uint amountTokenMin, uint amountETHMin, address to, uint deadline) external;
+    function migrate(address token, uint amountTokenMin, uint amountVETMin, address to, uint deadline) external;
 }

--- a/uniswap-v2-periphery/contracts/interfaces/IVexchangeV2Router01.sol
+++ b/uniswap-v2-periphery/contracts/interfaces/IVexchangeV2Router01.sol
@@ -2,7 +2,7 @@ pragma solidity >=0.6.2;
 
 interface IVexchangeV2Router01 {
     function factory() external pure returns (address);
-    function WETH() external pure returns (address);
+    function VVET() external pure returns (address);
 
     function addLiquidity(
         address tokenA,
@@ -14,14 +14,14 @@ interface IVexchangeV2Router01 {
         address to,
         uint deadline
     ) external returns (uint amountA, uint amountB, uint liquidity);
-    function addLiquidityETH(
+    function addLiquidityVET(
         address token,
         uint amountTokenDesired,
         uint amountTokenMin,
-        uint amountETHMin,
+        uint amountVETMin,
         address to,
         uint deadline
-    ) external payable returns (uint amountToken, uint amountETH, uint liquidity);
+    ) external payable returns (uint amountToken, uint amountVET, uint liquidity);
     function removeLiquidity(
         address tokenA,
         address tokenB,
@@ -31,14 +31,14 @@ interface IVexchangeV2Router01 {
         address to,
         uint deadline
     ) external returns (uint amountA, uint amountB);
-    function removeLiquidityETH(
+    function removeLiquidityVET(
         address token,
         uint liquidity,
         uint amountTokenMin,
-        uint amountETHMin,
+        uint amountVETMin,
         address to,
         uint deadline
-    ) external returns (uint amountToken, uint amountETH);
+    ) external returns (uint amountToken, uint amountVET);
     function removeLiquidityWithPermit(
         address tokenA,
         address tokenB,
@@ -49,15 +49,15 @@ interface IVexchangeV2Router01 {
         uint deadline,
         bool approveMax, uint8 v, bytes32 r, bytes32 s
     ) external returns (uint amountA, uint amountB);
-    function removeLiquidityETHWithPermit(
+    function removeLiquidityVETWithPermit(
         address token,
         uint liquidity,
         uint amountTokenMin,
-        uint amountETHMin,
+        uint amountVETMin,
         address to,
         uint deadline,
         bool approveMax, uint8 v, bytes32 r, bytes32 s
-    ) external returns (uint amountToken, uint amountETH);
+    ) external returns (uint amountToken, uint amountVET);
     function swapExactTokensForTokens(
         uint amountIn,
         uint amountOutMin,
@@ -72,17 +72,17 @@ interface IVexchangeV2Router01 {
         address to,
         uint deadline
     ) external returns (uint[] memory amounts);
-    function swapExactETHForTokens(uint amountOutMin, address[] calldata path, address to, uint deadline)
+    function swapExactVETForTokens(uint amountOutMin, address[] calldata path, address to, uint deadline)
         external
         payable
         returns (uint[] memory amounts);
-    function swapTokensForExactETH(uint amountOut, uint amountInMax, address[] calldata path, address to, uint deadline)
+    function swapTokensForExactVET(uint amountOut, uint amountInMax, address[] calldata path, address to, uint deadline)
         external
         returns (uint[] memory amounts);
-    function swapExactTokensForETH(uint amountIn, uint amountOutMin, address[] calldata path, address to, uint deadline)
+    function swapExactTokensForVET(uint amountIn, uint amountOutMin, address[] calldata path, address to, uint deadline)
         external
         returns (uint[] memory amounts);
-    function swapETHForExactTokens(uint amountOut, address[] calldata path, address to, uint deadline)
+    function swapVETForExactTokens(uint amountOut, address[] calldata path, address to, uint deadline)
         external
         payable
         returns (uint[] memory amounts);

--- a/uniswap-v2-periphery/contracts/interfaces/IVexchangeV2Router02.sol
+++ b/uniswap-v2-periphery/contracts/interfaces/IVexchangeV2Router02.sol
@@ -3,23 +3,23 @@ pragma solidity >=0.6.2;
 import './IVexchangeV2Router01.sol';
 
 interface IVexchangeV2Router02 is IVexchangeV2Router01 {
-    function removeLiquidityETHSupportingFeeOnTransferTokens(
+    function removeLiquidityVETSupportingFeeOnTransferTokens(
         address token,
         uint liquidity,
         uint amountTokenMin,
-        uint amountETHMin,
+        uint amountVETMin,
         address to,
         uint deadline
-    ) external returns (uint amountETH);
-    function removeLiquidityETHWithPermitSupportingFeeOnTransferTokens(
+    ) external returns (uint amountVET);
+    function removeLiquidityVETWithPermitSupportingFeeOnTransferTokens(
         address token,
         uint liquidity,
         uint amountTokenMin,
-        uint amountETHMin,
+        uint amountVETMin,
         address to,
         uint deadline,
         bool approveMax, uint8 v, bytes32 r, bytes32 s
-    ) external returns (uint amountETH);
+    ) external returns (uint amountVET);
 
     function swapExactTokensForTokensSupportingFeeOnTransferTokens(
         uint amountIn,
@@ -28,13 +28,13 @@ interface IVexchangeV2Router02 is IVexchangeV2Router01 {
         address to,
         uint deadline
     ) external;
-    function swapExactETHForTokensSupportingFeeOnTransferTokens(
+    function swapExactVETForTokensSupportingFeeOnTransferTokens(
         uint amountOutMin,
         address[] calldata path,
         address to,
         uint deadline
     ) external payable;
-    function swapExactTokensForETHSupportingFeeOnTransferTokens(
+    function swapExactTokensForVETSupportingFeeOnTransferTokens(
         uint amountIn,
         uint amountOutMin,
         address[] calldata path,

--- a/uniswap-v2-periphery/contracts/test/RouterEventEmitter.sol
+++ b/uniswap-v2-periphery/contracts/test/RouterEventEmitter.sol
@@ -37,7 +37,7 @@ contract RouterEventEmitter {
         emit Amounts(abi.decode(returnData, (uint[])));
     }
 
-    function swapExactETHForTokens(
+    function swapExactVETForTokens(
         address router,
         uint amountOutMin,
         address[] calldata path,
@@ -45,13 +45,13 @@ contract RouterEventEmitter {
         uint deadline
     ) external payable {
         (bool success, bytes memory returnData) = router.delegatecall(abi.encodeWithSelector(
-            IVexchangeV2Router01(router).swapExactETHForTokens.selector, amountOutMin, path, to, deadline
+            IVexchangeV2Router01(router).swapExactVETForTokens.selector, amountOutMin, path, to, deadline
         ));
         assert(success);
         emit Amounts(abi.decode(returnData, (uint[])));
     }
 
-    function swapTokensForExactETH(
+    function swapTokensForExactVET(
         address router,
         uint amountOut,
         uint amountInMax,
@@ -60,13 +60,13 @@ contract RouterEventEmitter {
         uint deadline
     ) external {
         (bool success, bytes memory returnData) = router.delegatecall(abi.encodeWithSelector(
-            IVexchangeV2Router01(router).swapTokensForExactETH.selector, amountOut, amountInMax, path, to, deadline
+            IVexchangeV2Router01(router).swapTokensForExactVET.selector, amountOut, amountInMax, path, to, deadline
         ));
         assert(success);
         emit Amounts(abi.decode(returnData, (uint[])));
     }
 
-    function swapExactTokensForETH(
+    function swapExactTokensForVET(
         address router,
         uint amountIn,
         uint amountOutMin,
@@ -75,13 +75,13 @@ contract RouterEventEmitter {
         uint deadline
     ) external {
         (bool success, bytes memory returnData) = router.delegatecall(abi.encodeWithSelector(
-            IVexchangeV2Router01(router).swapExactTokensForETH.selector, amountIn, amountOutMin, path, to, deadline
+            IVexchangeV2Router01(router).swapExactTokensForVET.selector, amountIn, amountOutMin, path, to, deadline
         ));
         assert(success);
         emit Amounts(abi.decode(returnData, (uint[])));
     }
 
-    function swapETHForExactTokens(
+    function swapVETForExactTokens(
         address router,
         uint amountOut,
         address[] calldata path,
@@ -89,7 +89,7 @@ contract RouterEventEmitter {
         uint deadline
     ) external payable {
         (bool success, bytes memory returnData) = router.delegatecall(abi.encodeWithSelector(
-            IVexchangeV2Router01(router).swapETHForExactTokens.selector, amountOut, path, to, deadline
+            IVexchangeV2Router01(router).swapVETForExactTokens.selector, amountOut, path, to, deadline
         ));
         assert(success);
         emit Amounts(abi.decode(returnData, (uint[])));

--- a/uniswap-v2-periphery/contracts/test/VVET9.sol
+++ b/uniswap-v2-periphery/contracts/test/VVET9.sol
@@ -1,0 +1,762 @@
+// Copyright (C) 2021 abyteahead
+// This program is forked from
+// https://github.com/gnosis/canonical-weth
+// Must be compiled with emv_version: constantinpole and above.
+
+// Copyright (C) 2015, 2016, 2017 Dapphub
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity =0.6.6;
+
+contract VVET9 {
+    string public name     = "Veiled VET";
+    string public symbol   = "VVET";
+    uint8  public decimals = 18;
+
+    event  Approval(address indexed src, address indexed guy, uint wad);
+    event  Transfer(address indexed src, address indexed dst, uint wad);
+    event  Deposit(address indexed dst, uint wad);
+    event  Withdrawal(address indexed src, uint wad);
+
+    mapping (address => uint)                       public  balanceOf;
+    mapping (address => mapping (address => uint))  public  allowance;
+
+    receive() external payable {
+        deposit();
+    }
+    
+    function deposit() public payable {
+        balanceOf[msg.sender] += msg.value;
+        emit Deposit(msg.sender, msg.value);
+    }
+    function withdraw(uint wad) public {
+        require(balanceOf[msg.sender] >= wad);
+        balanceOf[msg.sender] -= wad;
+        msg.sender.transfer(wad);
+        emit Withdrawal(msg.sender, wad);
+    }
+
+    function totalSupply() public view returns (uint) {
+        return address(this).balance;
+    }
+
+    function approve(address guy, uint wad) public returns (bool) {
+        allowance[msg.sender][guy] = wad;
+        emit Approval(msg.sender, guy, wad);
+        return true;
+    }
+
+    function transfer(address dst, uint wad) public returns (bool) {
+        return transferFrom(msg.sender, dst, wad);
+    }
+
+    function transferFrom(address src, address dst, uint wad)
+        public
+        returns (bool)
+    {
+        require(balanceOf[src] >= wad);
+
+        if (src != msg.sender && allowance[src][msg.sender] != uint(-1)) {
+            require(allowance[src][msg.sender] >= wad);
+            allowance[src][msg.sender] -= wad;
+        }
+
+        balanceOf[src] -= wad;
+        balanceOf[dst] += wad;
+
+        emit Transfer(src, dst, wad);
+
+        return true;
+    }
+}
+
+
+/*
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+
+*/

--- a/uniswap-v2-periphery/test/ExampleFlashSwap.spec.ts
+++ b/uniswap-v2-periphery/test/ExampleFlashSwap.spec.ts
@@ -25,18 +25,18 @@ describe('ExampleFlashSwap', () => {
   const [wallet] = provider.getWallets()
   const loadFixture = createFixtureLoader(provider, [wallet])
 
-  let WETH: Contract
-  let WETHPartner: Contract
-  let WETHExchangeV1: Contract
-  let WETHPair: Contract
+  let VVET: Contract
+  let VVETPartner: Contract
+  let VVETExchangeV1: Contract
+  let VVETPair: Contract
   let flashSwapExample: Contract
   beforeEach(async function() {
     const fixture = await loadFixture(v2Fixture)
 
-    WETH = fixture.WETH
-    WETHPartner = fixture.WETHPartner
-    WETHExchangeV1 = fixture.WETHExchangeV1
-    WETHPair = fixture.WETHPair
+    VVET = fixture.VVET
+    VVETPartner = fixture.VVETPartner
+    VVETExchangeV1 = fixture.VVETExchangeV1
+    VVETPair = fixture.VVETPair
     flashSwapExample = await deployContract(
       wallet,
       ExampleFlashSwap,
@@ -46,35 +46,35 @@ describe('ExampleFlashSwap', () => {
   })
 
   it('vexchangeV2Call:0', async () => {
-    // add liquidity to V1 at a rate of 1 ETH / 200 X
-    const WETHPartnerAmountV1 = expandTo18Decimals(2000)
-    const ETHAmountV1 = expandTo18Decimals(10)
-    await WETHPartner.approve(WETHExchangeV1.address, WETHPartnerAmountV1)
-    await WETHExchangeV1.addLiquidity(bigNumberify(1), WETHPartnerAmountV1, MaxUint256, {
+    // add liquidity to V1 at a rate of 1 VET / 200 X
+    const VVETPartnerAmountV1 = expandTo18Decimals(2000)
+    const VETAmountV1 = expandTo18Decimals(10)
+    await VVETPartner.approve(VVETExchangeV1.address, VVETPartnerAmountV1)
+    await VVETExchangeV1.addLiquidity(bigNumberify(1), VVETPartnerAmountV1, MaxUint256, {
       ...overrides,
-      value: ETHAmountV1
+      value: VETAmountV1
     })
 
-    // add liquidity to V2 at a rate of 1 ETH / 100 X
-    const WETHPartnerAmountV2 = expandTo18Decimals(1000)
-    const ETHAmountV2 = expandTo18Decimals(10)
-    await WETHPartner.transfer(WETHPair.address, WETHPartnerAmountV2)
-    await WETH.deposit({ value: ETHAmountV2 })
-    await WETH.transfer(WETHPair.address, ETHAmountV2)
-    await WETHPair.mint(wallet.address, overrides)
+    // add liquidity to V2 at a rate of 1 VET / 100 X
+    const VVETPartnerAmountV2 = expandTo18Decimals(1000)
+    const VETAmountV2 = expandTo18Decimals(10)
+    await VVETPartner.transfer(VVETPair.address, VVETPartnerAmountV2)
+    await VVET.deposit({ value: VETAmountV2 })
+    await VVET.transfer(VVETPair.address, VETAmountV2)
+    await VVETPair.mint(wallet.address, overrides)
 
-    const balanceBefore = await WETHPartner.balanceOf(wallet.address)
+    const balanceBefore = await VVETPartner.balanceOf(wallet.address)
 
     // now, execute arbitrage via vexchangeV2Call:
-    // receive 1 ETH from V2, get as much X from V1 as we can, repay V2 with minimum X, keep the rest!
+    // receive 1 VET from V2, get as much X from V1 as we can, repay V2 with minimum X, keep the rest!
     const arbitrageAmount = expandTo18Decimals(1)
     // instead of being 'hard-coded', the above value could be calculated optimally off-chain. this would be
     // better, but it'd be better yet to calculate the amount at runtime, on-chain. unfortunately, this requires a
     // swap-to-price calculation, which is a little tricky, and out of scope for the moment
-    const WETHPairToken0 = await WETHPair.token0()
-    const amount0 = WETHPairToken0 === WETHPartner.address ? bigNumberify(0) : arbitrageAmount
-    const amount1 = WETHPairToken0 === WETHPartner.address ? arbitrageAmount : bigNumberify(0)
-    await WETHPair.swap(
+    const VVETPairToken0 = await VVETPair.token0()
+    const amount0 = VVETPairToken0 === VVETPartner.address ? bigNumberify(0) : arbitrageAmount
+    const amount1 = VVETPairToken0 === VVETPartner.address ? arbitrageAmount : bigNumberify(0)
+    await VVETPair.swap(
       amount0,
       amount1,
       flashSwapExample.address,
@@ -82,16 +82,16 @@ describe('ExampleFlashSwap', () => {
       overrides
     )
 
-    const balanceAfter = await WETHPartner.balanceOf(wallet.address)
+    const balanceAfter = await VVETPartner.balanceOf(wallet.address)
     const profit = balanceAfter.sub(balanceBefore).div(expandTo18Decimals(1))
     const reservesV1 = [
-      await WETHPartner.balanceOf(WETHExchangeV1.address),
-      await provider.getBalance(WETHExchangeV1.address)
+      await VVETPartner.balanceOf(VVETExchangeV1.address),
+      await provider.getBalance(VVETExchangeV1.address)
     ]
     const priceV1 = reservesV1[0].div(reservesV1[1])
-    const reservesV2 = (await WETHPair.getReserves()).slice(0, 2)
+    const reservesV2 = (await VVETPair.getReserves()).slice(0, 2)
     const priceV2 =
-      WETHPairToken0 === WETHPartner.address ? reservesV2[0].div(reservesV2[1]) : reservesV2[1].div(reservesV2[0])
+      VVETPairToken0 === VVETPartner.address ? reservesV2[0].div(reservesV2[1]) : reservesV2[1].div(reservesV2[0])
 
     expect(profit.toString()).to.eq('69') // our profit is ~69 tokens
     expect(priceV1.toString()).to.eq('165') // we pushed the v1 price down to ~165
@@ -99,35 +99,35 @@ describe('ExampleFlashSwap', () => {
   })
 
   it('vexchangeV2Call:1', async () => {
-    // add liquidity to V1 at a rate of 1 ETH / 100 X
-    const WETHPartnerAmountV1 = expandTo18Decimals(1000)
-    const ETHAmountV1 = expandTo18Decimals(10)
-    await WETHPartner.approve(WETHExchangeV1.address, WETHPartnerAmountV1)
-    await WETHExchangeV1.addLiquidity(bigNumberify(1), WETHPartnerAmountV1, MaxUint256, {
+    // add liquidity to V1 at a rate of 1 VET / 100 X
+    const VVETPartnerAmountV1 = expandTo18Decimals(1000)
+    const VETAmountV1 = expandTo18Decimals(10)
+    await VVETPartner.approve(VVETExchangeV1.address, VVETPartnerAmountV1)
+    await VVETExchangeV1.addLiquidity(bigNumberify(1), VVETPartnerAmountV1, MaxUint256, {
       ...overrides,
-      value: ETHAmountV1
+      value: VETAmountV1
     })
 
-    // add liquidity to V2 at a rate of 1 ETH / 200 X
-    const WETHPartnerAmountV2 = expandTo18Decimals(2000)
-    const ETHAmountV2 = expandTo18Decimals(10)
-    await WETHPartner.transfer(WETHPair.address, WETHPartnerAmountV2)
-    await WETH.deposit({ value: ETHAmountV2 })
-    await WETH.transfer(WETHPair.address, ETHAmountV2)
-    await WETHPair.mint(wallet.address, overrides)
+    // add liquidity to V2 at a rate of 1 VET / 200 X
+    const VVETPartnerAmountV2 = expandTo18Decimals(2000)
+    const VETAmountV2 = expandTo18Decimals(10)
+    await VVETPartner.transfer(VVETPair.address, VVETPartnerAmountV2)
+    await VVET.deposit({ value: VETAmountV2 })
+    await VVET.transfer(VVETPair.address, VETAmountV2)
+    await VVETPair.mint(wallet.address, overrides)
 
     const balanceBefore = await provider.getBalance(wallet.address)
 
     // now, execute arbitrage via vexchangeV2Call:
-    // receive 200 X from V2, get as much ETH from V1 as we can, repay V2 with minimum ETH, keep the rest!
+    // receive 200 X from V2, get as much VET from V1 as we can, repay V2 with minimum VET, keep the rest!
     const arbitrageAmount = expandTo18Decimals(200)
     // instead of being 'hard-coded', the above value could be calculated optimally off-chain. this would be
     // better, but it'd be better yet to calculate the amount at runtime, on-chain. unfortunately, this requires a
     // swap-to-price calculation, which is a little tricky, and out of scope for the moment
-    const WETHPairToken0 = await WETHPair.token0()
-    const amount0 = WETHPairToken0 === WETHPartner.address ? arbitrageAmount : bigNumberify(0)
-    const amount1 = WETHPairToken0 === WETHPartner.address ? bigNumberify(0) : arbitrageAmount
-    await WETHPair.swap(
+    const VVETPairToken0 = await VVETPair.token0()
+    const amount0 = VVETPairToken0 === VVETPartner.address ? arbitrageAmount : bigNumberify(0)
+    const amount1 = VVETPairToken0 === VVETPartner.address ? bigNumberify(0) : arbitrageAmount
+    await VVETPair.swap(
       amount0,
       amount1,
       flashSwapExample.address,
@@ -138,15 +138,15 @@ describe('ExampleFlashSwap', () => {
     const balanceAfter = await provider.getBalance(wallet.address)
     const profit = balanceAfter.sub(balanceBefore)
     const reservesV1 = [
-      await WETHPartner.balanceOf(WETHExchangeV1.address),
-      await provider.getBalance(WETHExchangeV1.address)
+      await VVETPartner.balanceOf(VVETExchangeV1.address),
+      await provider.getBalance(VVETExchangeV1.address)
     ]
     const priceV1 = reservesV1[0].div(reservesV1[1])
-    const reservesV2 = (await WETHPair.getReserves()).slice(0, 2)
+    const reservesV2 = (await VVETPair.getReserves()).slice(0, 2)
     const priceV2 =
-      WETHPairToken0 === WETHPartner.address ? reservesV2[0].div(reservesV2[1]) : reservesV2[1].div(reservesV2[0])
+      VVETPairToken0 === VVETPartner.address ? reservesV2[0].div(reservesV2[1]) : reservesV2[1].div(reservesV2[0])
 
-    expect(formatEther(profit)).to.eq('0.548043441089763649') // our profit is ~.5 ETH
+    expect(formatEther(profit)).to.eq('0.548043441089763649') // our profit is ~.5 VET
     expect(priceV1.toString()).to.eq('143') // we pushed the v1 price up to ~143
     expect(priceV2.toString()).to.eq('161') // we pushed the v2 price down to ~161
   })

--- a/uniswap-v2-periphery/test/ExampleSlidingWindowOracle.spec.ts
+++ b/uniswap-v2-periphery/test/ExampleSlidingWindowOracle.spec.ts
@@ -29,7 +29,7 @@ describe('ExampleSlidingWindowOracle', () => {
   let token0: Contract
   let token1: Contract
   let pair: Contract
-  let weth: Contract
+  let vvet: Contract
   let factory: Contract
 
   async function addLiquidity(amount0: BigNumber = defaultToken0Amount, amount1: BigNumber = defaultToken1Amount) {
@@ -61,7 +61,7 @@ describe('ExampleSlidingWindowOracle', () => {
     token0 = fixture.token0
     token1 = fixture.token1
     pair = fixture.pair
-    weth = fixture.WETH
+    vvet = fixture.VVET
     factory = fixture.factoryV2
   })
 
@@ -180,7 +180,7 @@ describe('ExampleSlidingWindowOracle', () => {
     })
 
     it('fails for invalid pair', async () => {
-      await expect(slidingWindowOracle.update(weth.address, token1.address)).to.be.reverted
+      await expect(slidingWindowOracle.update(vvet.address, token1.address)).to.be.reverted
     })
   })
 
@@ -203,7 +203,7 @@ describe('ExampleSlidingWindowOracle', () => {
     })
 
     it('fails for invalid pair', async () => {
-      await expect(slidingWindowOracle.consult(weth.address, 0, token1.address)).to.be.reverted
+      await expect(slidingWindowOracle.consult(vvet.address, 0, token1.address)).to.be.reverted
     })
 
     describe('happy path', () => {

--- a/uniswap-v2-periphery/test/ExampleSwapToPrice.spec.ts
+++ b/uniswap-v2-periphery/test/ExampleSwapToPrice.spec.ts
@@ -192,7 +192,9 @@ describe('ExampleSwapToPrice', () => {
         overrides
       )
       const receipt = await tx.wait()
-      expect(receipt.gasUsed).to.eq('108950')
-    }).retries(2) // gas test is inconsistent
+      expect(receipt.gasUsed).to.satisfy( function(gas: number) {
+        return ((gas==108906  || gas==149722))
+      }) // gas test is inconsistent
+    })
   })
 })

--- a/uniswap-v2-periphery/test/VexchangeV2Migrator.spec.ts
+++ b/uniswap-v2-periphery/test/VexchangeV2Migrator.spec.ts
@@ -22,49 +22,49 @@ describe('VexchangeV2Migrator', () => {
   const [wallet] = provider.getWallets()
   const loadFixture = createFixtureLoader(provider, [wallet])
 
-  let WETHPartner: Contract
-  let WETHPair: Contract
+  let VVETPartner: Contract
+  let VVETPair: Contract
   let router: Contract
   let migrator: Contract
-  let WETHExchangeV1: Contract
+  let VVETExchangeV1: Contract
   beforeEach(async function() {
     const fixture = await loadFixture(v2Fixture)
-    WETHPartner = fixture.WETHPartner
-    WETHPair = fixture.WETHPair
+    VVETPartner = fixture.VVETPartner
+    VVETPair = fixture.VVETPair
     router = fixture.router01 // we used router01 for this contract
     migrator = fixture.migrator
-    WETHExchangeV1 = fixture.WETHExchangeV1
+    VVETExchangeV1 = fixture.VVETExchangeV1
   })
 
   it('migrate', async () => {
-    const WETHPartnerAmount = expandTo18Decimals(1)
-    const ETHAmount = expandTo18Decimals(4)
-    await WETHPartner.approve(WETHExchangeV1.address, MaxUint256)
-    await WETHExchangeV1.addLiquidity(bigNumberify(1), WETHPartnerAmount, MaxUint256, {
+    const VVETPartnerAmount = expandTo18Decimals(1)
+    const VETAmount = expandTo18Decimals(4)
+    await VVETPartner.approve(VVETExchangeV1.address, MaxUint256)
+    await VVETExchangeV1.addLiquidity(bigNumberify(1), VVETPartnerAmount, MaxUint256, {
       ...overrides,
-      value: ETHAmount
+      value: VETAmount
     })
-    await WETHExchangeV1.approve(migrator.address, MaxUint256)
+    await VVETExchangeV1.approve(migrator.address, MaxUint256)
     const expectedLiquidity = expandTo18Decimals(2)
-    const WETHPairToken0 = await WETHPair.token0()
+    const VVETPairToken0 = await VVETPair.token0()
     await expect(
-      migrator.migrate(WETHPartner.address, WETHPartnerAmount, ETHAmount, wallet.address, MaxUint256, overrides)
+      migrator.migrate(VVETPartner.address, VVETPartnerAmount, VETAmount, wallet.address, MaxUint256, overrides)
     )
-      .to.emit(WETHPair, 'Transfer')
+      .to.emit(VVETPair, 'Transfer')
       .withArgs(AddressZero, AddressZero, MINIMUM_LIQUIDITY)
-      .to.emit(WETHPair, 'Transfer')
+      .to.emit(VVETPair, 'Transfer')
       .withArgs(AddressZero, wallet.address, expectedLiquidity.sub(MINIMUM_LIQUIDITY))
-      .to.emit(WETHPair, 'Sync')
+      .to.emit(VVETPair, 'Sync')
       .withArgs(
-        WETHPairToken0 === WETHPartner.address ? WETHPartnerAmount : ETHAmount,
-        WETHPairToken0 === WETHPartner.address ? ETHAmount : WETHPartnerAmount
+        VVETPairToken0 === VVETPartner.address ? VVETPartnerAmount : VETAmount,
+        VVETPairToken0 === VVETPartner.address ? VETAmount : VVETPartnerAmount
       )
-      .to.emit(WETHPair, 'Mint')
+      .to.emit(VVETPair, 'Mint')
       .withArgs(
         router.address,
-        WETHPairToken0 === WETHPartner.address ? WETHPartnerAmount : ETHAmount,
-        WETHPairToken0 === WETHPartner.address ? ETHAmount : WETHPartnerAmount
+        VVETPairToken0 === VVETPartner.address ? VVETPartnerAmount : VETAmount,
+        VVETPairToken0 === VVETPartner.address ? VETAmount : VVETPartnerAmount
       )
-    expect(await WETHPair.balanceOf(wallet.address)).to.eq(expectedLiquidity.sub(MINIMUM_LIQUIDITY))
+    expect(await VVETPair.balanceOf(wallet.address)).to.eq(expectedLiquidity.sub(MINIMUM_LIQUIDITY))
   })
 })

--- a/uniswap-v2-periphery/test/VexchangeV2Router01.spec.ts
+++ b/uniswap-v2-periphery/test/VexchangeV2Router01.spec.ts
@@ -31,26 +31,26 @@ describe('VexchangeV2Router{01,02}', () => {
 
     let token0: Contract
     let token1: Contract
-    let WETH: Contract
-    let WETHPartner: Contract
+    let VVET: Contract
+    let VVETPartner: Contract
     let factory: Contract
     let router: Contract
     let pair: Contract
-    let WETHPair: Contract
+    let VVETPair: Contract
     let routerEventEmitter: Contract
     beforeEach(async function() {
       const fixture = await loadFixture(v2Fixture)
       token0 = fixture.token0
       token1 = fixture.token1
-      WETH = fixture.WETH
-      WETHPartner = fixture.WETHPartner
+      VVET = fixture.VVET
+      VVETPartner = fixture.VVETPartner
       factory = fixture.factoryV2
       router = {
         [RouterVersion.VexchangeV2Router01]: fixture.router01,
         [RouterVersion.VexchangeV2Router02]: fixture.router02
       }[routerVersion as RouterVersion]
       pair = fixture.pair
-      WETHPair = fixture.WETHPair
+      VVETPair = fixture.VVETPair
       routerEventEmitter = fixture.routerEventEmitter
     })
 
@@ -59,9 +59,9 @@ describe('VexchangeV2Router{01,02}', () => {
     })
 
     describe(routerVersion, () => {
-      it('factory, WETH', async () => {
+      it('factory, VVET', async () => {
         expect(await router.factory()).to.eq(factory.address)
-        expect(await router.WETH()).to.eq(WETH.address)
+        expect(await router.VVET()).to.eq(VVET.address)
       })
 
       it('addLiquidity', async () => {
@@ -100,41 +100,41 @@ describe('VexchangeV2Router{01,02}', () => {
         expect(await pair.balanceOf(wallet.address)).to.eq(expectedLiquidity.sub(MINIMUM_LIQUIDITY))
       })
 
-      it('addLiquidityETH', async () => {
-        const WETHPartnerAmount = expandTo18Decimals(1)
-        const ETHAmount = expandTo18Decimals(4)
+      it('addLiquidityVET', async () => {
+        const VVETPartnerAmount = expandTo18Decimals(1)
+        const VETAmount = expandTo18Decimals(4)
 
         const expectedLiquidity = expandTo18Decimals(2)
-        const WETHPairToken0 = await WETHPair.token0()
-        await WETHPartner.approve(router.address, MaxUint256)
+        const VVETPairToken0 = await VVETPair.token0()
+        await VVETPartner.approve(router.address, MaxUint256)
         await expect(
-          router.addLiquidityETH(
-            WETHPartner.address,
-            WETHPartnerAmount,
-            WETHPartnerAmount,
-            ETHAmount,
+          router.addLiquidityVET(
+            VVETPartner.address,
+            VVETPartnerAmount,
+            VVETPartnerAmount,
+            VETAmount,
             wallet.address,
             MaxUint256,
-            { ...overrides, value: ETHAmount }
+            { ...overrides, value: VETAmount }
           )
         )
-          .to.emit(WETHPair, 'Transfer')
+          .to.emit(VVETPair, 'Transfer')
           .withArgs(AddressZero, AddressZero, MINIMUM_LIQUIDITY)
-          .to.emit(WETHPair, 'Transfer')
+          .to.emit(VVETPair, 'Transfer')
           .withArgs(AddressZero, wallet.address, expectedLiquidity.sub(MINIMUM_LIQUIDITY))
-          .to.emit(WETHPair, 'Sync')
+          .to.emit(VVETPair, 'Sync')
           .withArgs(
-            WETHPairToken0 === WETHPartner.address ? WETHPartnerAmount : ETHAmount,
-            WETHPairToken0 === WETHPartner.address ? ETHAmount : WETHPartnerAmount
+            VVETPairToken0 === VVETPartner.address ? VVETPartnerAmount : VETAmount,
+            VVETPairToken0 === VVETPartner.address ? VETAmount : VVETPartnerAmount
           )
-          .to.emit(WETHPair, 'Mint')
+          .to.emit(VVETPair, 'Mint')
           .withArgs(
             router.address,
-            WETHPairToken0 === WETHPartner.address ? WETHPartnerAmount : ETHAmount,
-            WETHPairToken0 === WETHPartner.address ? ETHAmount : WETHPartnerAmount
+            VVETPairToken0 === VVETPartner.address ? VVETPartnerAmount : VETAmount,
+            VVETPairToken0 === VVETPartner.address ? VETAmount : VVETPartnerAmount
           )
 
-        expect(await WETHPair.balanceOf(wallet.address)).to.eq(expectedLiquidity.sub(MINIMUM_LIQUIDITY))
+        expect(await VVETPair.balanceOf(wallet.address)).to.eq(expectedLiquidity.sub(MINIMUM_LIQUIDITY))
       })
 
       async function addLiquidity(token0Amount: BigNumber, token1Amount: BigNumber) {
@@ -181,20 +181,20 @@ describe('VexchangeV2Router{01,02}', () => {
         expect(await token1.balanceOf(wallet.address)).to.eq(totalSupplyToken1.sub(2000))
       })
 
-      it('removeLiquidityETH', async () => {
-        const WETHPartnerAmount = expandTo18Decimals(1)
-        const ETHAmount = expandTo18Decimals(4)
-        await WETHPartner.transfer(WETHPair.address, WETHPartnerAmount)
-        await WETH.deposit({ value: ETHAmount })
-        await WETH.transfer(WETHPair.address, ETHAmount)
-        await WETHPair.mint(wallet.address, overrides)
+      it('removeLiquidityVET', async () => {
+        const VVETPartnerAmount = expandTo18Decimals(1)
+        const VETAmount = expandTo18Decimals(4)
+        await VVETPartner.transfer(VVETPair.address, VVETPartnerAmount)
+        await VVET.deposit({ value: VETAmount })
+        await VVET.transfer(VVETPair.address, VETAmount)
+        await VVETPair.mint(wallet.address, overrides)
 
         const expectedLiquidity = expandTo18Decimals(2)
-        const WETHPairToken0 = await WETHPair.token0()
-        await WETHPair.approve(router.address, MaxUint256)
+        const VVETPairToken0 = await VVETPair.token0()
+        await VVETPair.approve(router.address, MaxUint256)
         await expect(
-          router.removeLiquidityETH(
-            WETHPartner.address,
+          router.removeLiquidityVET(
+            VVETPartner.address,
             expectedLiquidity.sub(MINIMUM_LIQUIDITY),
             0,
             0,
@@ -203,34 +203,34 @@ describe('VexchangeV2Router{01,02}', () => {
             overrides
           )
         )
-          .to.emit(WETHPair, 'Transfer')
-          .withArgs(wallet.address, WETHPair.address, expectedLiquidity.sub(MINIMUM_LIQUIDITY))
-          .to.emit(WETHPair, 'Transfer')
-          .withArgs(WETHPair.address, AddressZero, expectedLiquidity.sub(MINIMUM_LIQUIDITY))
-          .to.emit(WETH, 'Transfer')
-          .withArgs(WETHPair.address, router.address, ETHAmount.sub(2000))
-          .to.emit(WETHPartner, 'Transfer')
-          .withArgs(WETHPair.address, router.address, WETHPartnerAmount.sub(500))
-          .to.emit(WETHPartner, 'Transfer')
-          .withArgs(router.address, wallet.address, WETHPartnerAmount.sub(500))
-          .to.emit(WETHPair, 'Sync')
+          .to.emit(VVETPair, 'Transfer')
+          .withArgs(wallet.address, VVETPair.address, expectedLiquidity.sub(MINIMUM_LIQUIDITY))
+          .to.emit(VVETPair, 'Transfer')
+          .withArgs(VVETPair.address, AddressZero, expectedLiquidity.sub(MINIMUM_LIQUIDITY))
+          .to.emit(VVET, 'Transfer')
+          .withArgs(VVETPair.address, router.address, VETAmount.sub(2000))
+          .to.emit(VVETPartner, 'Transfer')
+          .withArgs(VVETPair.address, router.address, VVETPartnerAmount.sub(500))
+          .to.emit(VVETPartner, 'Transfer')
+          .withArgs(router.address, wallet.address, VVETPartnerAmount.sub(500))
+          .to.emit(VVETPair, 'Sync')
           .withArgs(
-            WETHPairToken0 === WETHPartner.address ? 500 : 2000,
-            WETHPairToken0 === WETHPartner.address ? 2000 : 500
+            VVETPairToken0 === VVETPartner.address ? 500 : 2000,
+            VVETPairToken0 === VVETPartner.address ? 2000 : 500
           )
-          .to.emit(WETHPair, 'Burn')
+          .to.emit(VVETPair, 'Burn')
           .withArgs(
             router.address,
-            WETHPairToken0 === WETHPartner.address ? WETHPartnerAmount.sub(500) : ETHAmount.sub(2000),
-            WETHPairToken0 === WETHPartner.address ? ETHAmount.sub(2000) : WETHPartnerAmount.sub(500),
+            VVETPairToken0 === VVETPartner.address ? VVETPartnerAmount.sub(500) : VETAmount.sub(2000),
+            VVETPairToken0 === VVETPartner.address ? VETAmount.sub(2000) : VVETPartnerAmount.sub(500),
             router.address
           )
 
-        expect(await WETHPair.balanceOf(wallet.address)).to.eq(0)
-        const totalSupplyWETHPartner = await WETHPartner.totalSupply()
-        const totalSupplyWETH = await WETH.totalSupply()
-        expect(await WETHPartner.balanceOf(wallet.address)).to.eq(totalSupplyWETHPartner.sub(500))
-        expect(await WETH.balanceOf(wallet.address)).to.eq(totalSupplyWETH.sub(2000))
+        expect(await VVETPair.balanceOf(wallet.address)).to.eq(0)
+        const totalSupplyVVETPartner = await VVETPartner.totalSupply()
+        const totalSupplyVVET = await VVET.totalSupply()
+        expect(await VVETPartner.balanceOf(wallet.address)).to.eq(totalSupplyVVETPartner.sub(500))
+        expect(await VVET.balanceOf(wallet.address)).to.eq(totalSupplyVVET.sub(2000))
       })
 
       it('removeLiquidityWithPermit', async () => {
@@ -267,19 +267,19 @@ describe('VexchangeV2Router{01,02}', () => {
         )
       })
 
-      it('removeLiquidityETHWithPermit', async () => {
-        const WETHPartnerAmount = expandTo18Decimals(1)
-        const ETHAmount = expandTo18Decimals(4)
-        await WETHPartner.transfer(WETHPair.address, WETHPartnerAmount)
-        await WETH.deposit({ value: ETHAmount })
-        await WETH.transfer(WETHPair.address, ETHAmount)
-        await WETHPair.mint(wallet.address, overrides)
+      it('removeLiquidityVETWithPermit', async () => {
+        const VVETPartnerAmount = expandTo18Decimals(1)
+        const VETAmount = expandTo18Decimals(4)
+        await VVETPartner.transfer(VVETPair.address, VVETPartnerAmount)
+        await VVET.deposit({ value: VETAmount })
+        await VVET.transfer(VVETPair.address, VETAmount)
+        await VVETPair.mint(wallet.address, overrides)
 
         const expectedLiquidity = expandTo18Decimals(2)
 
-        const nonce = await WETHPair.nonces(wallet.address)
+        const nonce = await VVETPair.nonces(wallet.address)
         const digest = await getApprovalDigest(
-          WETHPair,
+          VVETPair,
           { owner: wallet.address, spender: router.address, value: expectedLiquidity.sub(MINIMUM_LIQUIDITY) },
           nonce,
           MaxUint256,
@@ -288,8 +288,8 @@ describe('VexchangeV2Router{01,02}', () => {
 
         const { v, r, s } = ecsign(Buffer.from(digest.slice(2), 'hex'), Buffer.from(wallet.privateKey.slice(2), 'hex'))
 
-        await router.removeLiquidityETHWithPermit(
-          WETHPartner.address,
+        await router.removeLiquidityVETWithPermit(
+          VVETPartner.address,
           expectedLiquidity.sub(MINIMUM_LIQUIDITY),
           0,
           0,
@@ -427,59 +427,59 @@ describe('VexchangeV2Router{01,02}', () => {
         })
       })
 
-      describe('swapExactETHForTokens', () => {
-        const WETHPartnerAmount = expandTo18Decimals(10)
-        const ETHAmount = expandTo18Decimals(5)
+      describe('swapExactVETForTokens', () => {
+        const VVETPartnerAmount = expandTo18Decimals(10)
+        const VETAmount = expandTo18Decimals(5)
         const swapAmount = expandTo18Decimals(1)
         const expectedOutputAmount = bigNumberify('1662497915624478906')
 
         beforeEach(async () => {
-          await WETHPartner.transfer(WETHPair.address, WETHPartnerAmount)
-          await WETH.deposit({ value: ETHAmount })
-          await WETH.transfer(WETHPair.address, ETHAmount)
-          await WETHPair.mint(wallet.address, overrides)
+          await VVETPartner.transfer(VVETPair.address, VVETPartnerAmount)
+          await VVET.deposit({ value: VETAmount })
+          await VVET.transfer(VVETPair.address, VETAmount)
+          await VVETPair.mint(wallet.address, overrides)
 
           await token0.approve(router.address, MaxUint256)
         })
 
         it('happy path', async () => {
-          const WETHPairToken0 = await WETHPair.token0()
+          const VVETPairToken0 = await VVETPair.token0()
           await expect(
-            router.swapExactETHForTokens(0, [WETH.address, WETHPartner.address], wallet.address, MaxUint256, {
+            router.swapExactVETForTokens(0, [VVET.address, VVETPartner.address], wallet.address, MaxUint256, {
               ...overrides,
               value: swapAmount
             })
           )
-            .to.emit(WETH, 'Transfer')
-            .withArgs(router.address, WETHPair.address, swapAmount)
-            .to.emit(WETHPartner, 'Transfer')
-            .withArgs(WETHPair.address, wallet.address, expectedOutputAmount)
-            .to.emit(WETHPair, 'Sync')
+            .to.emit(VVET, 'Transfer')
+            .withArgs(router.address, VVETPair.address, swapAmount)
+            .to.emit(VVETPartner, 'Transfer')
+            .withArgs(VVETPair.address, wallet.address, expectedOutputAmount)
+            .to.emit(VVETPair, 'Sync')
             .withArgs(
-              WETHPairToken0 === WETHPartner.address
-                ? WETHPartnerAmount.sub(expectedOutputAmount)
-                : ETHAmount.add(swapAmount),
-              WETHPairToken0 === WETHPartner.address
-                ? ETHAmount.add(swapAmount)
-                : WETHPartnerAmount.sub(expectedOutputAmount)
+              VVETPairToken0 === VVETPartner.address
+                ? VVETPartnerAmount.sub(expectedOutputAmount)
+                : VETAmount.add(swapAmount),
+              VVETPairToken0 === VVETPartner.address
+                ? VETAmount.add(swapAmount)
+                : VVETPartnerAmount.sub(expectedOutputAmount)
             )
-            .to.emit(WETHPair, 'Swap')
+            .to.emit(VVETPair, 'Swap')
             .withArgs(
               router.address,
-              WETHPairToken0 === WETHPartner.address ? 0 : swapAmount,
-              WETHPairToken0 === WETHPartner.address ? swapAmount : 0,
-              WETHPairToken0 === WETHPartner.address ? expectedOutputAmount : 0,
-              WETHPairToken0 === WETHPartner.address ? 0 : expectedOutputAmount,
+              VVETPairToken0 === VVETPartner.address ? 0 : swapAmount,
+              VVETPairToken0 === VVETPartner.address ? swapAmount : 0,
+              VVETPairToken0 === VVETPartner.address ? expectedOutputAmount : 0,
+              VVETPairToken0 === VVETPartner.address ? 0 : expectedOutputAmount,
               wallet.address
             )
         })
 
         it('amounts', async () => {
           await expect(
-            routerEventEmitter.swapExactETHForTokens(
+            routerEventEmitter.swapExactVETForTokens(
               router.address,
               0,
-              [WETH.address, WETHPartner.address],
+              [VVET.address, VVETPartner.address],
               wallet.address,
               MaxUint256,
               {
@@ -493,12 +493,12 @@ describe('VexchangeV2Router{01,02}', () => {
         })
 
         it('gas', async () => {
-          const WETHPartnerAmount = expandTo18Decimals(10)
-          const ETHAmount = expandTo18Decimals(5)
-          await WETHPartner.transfer(WETHPair.address, WETHPartnerAmount)
-          await WETH.deposit({ value: ETHAmount })
-          await WETH.transfer(WETHPair.address, ETHAmount)
-          await WETHPair.mint(wallet.address, overrides)
+          const VVETPartnerAmount = expandTo18Decimals(10)
+          const VETAmount = expandTo18Decimals(5)
+          await VVETPartner.transfer(VVETPair.address, VVETPartnerAmount)
+          await VVET.deposit({ value: VETAmount })
+          await VVET.transfer(VVETPair.address, VETAmount)
+          await VVETPair.mint(wallet.address, overrides)
 
           // ensure that setting price{0,1}CumulativeLast for the first time doesn't affect our gas math
           await mineBlock(provider, (await provider.getBlock('latest')).timestamp + 1)
@@ -506,9 +506,9 @@ describe('VexchangeV2Router{01,02}', () => {
 
           const swapAmount = expandTo18Decimals(1)
           await mineBlock(provider, (await provider.getBlock('latest')).timestamp + 1)
-          const tx = await router.swapExactETHForTokens(
+          const tx = await router.swapExactVETForTokens(
             0,
-            [WETH.address, WETHPartner.address],
+            [VVET.address, VVETPartner.address],
             wallet.address,
             MaxUint256,
             {
@@ -526,64 +526,64 @@ describe('VexchangeV2Router{01,02}', () => {
         }).retries(3)
       })
 
-      describe('swapTokensForExactETH', () => {
-        const WETHPartnerAmount = expandTo18Decimals(5)
-        const ETHAmount = expandTo18Decimals(10)
+      describe('swapTokensForExactVET', () => {
+        const VVETPartnerAmount = expandTo18Decimals(5)
+        const VETAmount = expandTo18Decimals(10)
         const expectedSwapAmount = bigNumberify('557227237267357629')
         const outputAmount = expandTo18Decimals(1)
 
         beforeEach(async () => {
-          await WETHPartner.transfer(WETHPair.address, WETHPartnerAmount)
-          await WETH.deposit({ value: ETHAmount })
-          await WETH.transfer(WETHPair.address, ETHAmount)
-          await WETHPair.mint(wallet.address, overrides)
+          await VVETPartner.transfer(VVETPair.address, VVETPartnerAmount)
+          await VVET.deposit({ value: VETAmount })
+          await VVET.transfer(VVETPair.address, VETAmount)
+          await VVETPair.mint(wallet.address, overrides)
         })
 
         it('happy path', async () => {
-          await WETHPartner.approve(router.address, MaxUint256)
-          const WETHPairToken0 = await WETHPair.token0()
+          await VVETPartner.approve(router.address, MaxUint256)
+          const VVETPairToken0 = await VVETPair.token0()
           await expect(
-            router.swapTokensForExactETH(
+            router.swapTokensForExactVET(
               outputAmount,
               MaxUint256,
-              [WETHPartner.address, WETH.address],
+              [VVETPartner.address, VVET.address],
               wallet.address,
               MaxUint256,
               overrides
             )
           )
-            .to.emit(WETHPartner, 'Transfer')
-            .withArgs(wallet.address, WETHPair.address, expectedSwapAmount)
-            .to.emit(WETH, 'Transfer')
-            .withArgs(WETHPair.address, router.address, outputAmount)
-            .to.emit(WETHPair, 'Sync')
+            .to.emit(VVETPartner, 'Transfer')
+            .withArgs(wallet.address, VVETPair.address, expectedSwapAmount)
+            .to.emit(VVET, 'Transfer')
+            .withArgs(VVETPair.address, router.address, outputAmount)
+            .to.emit(VVETPair, 'Sync')
             .withArgs(
-              WETHPairToken0 === WETHPartner.address
-                ? WETHPartnerAmount.add(expectedSwapAmount)
-                : ETHAmount.sub(outputAmount),
-              WETHPairToken0 === WETHPartner.address
-                ? ETHAmount.sub(outputAmount)
-                : WETHPartnerAmount.add(expectedSwapAmount)
+              VVETPairToken0 === VVETPartner.address
+                ? VVETPartnerAmount.add(expectedSwapAmount)
+                : VETAmount.sub(outputAmount),
+              VVETPairToken0 === VVETPartner.address
+                ? VETAmount.sub(outputAmount)
+                : VVETPartnerAmount.add(expectedSwapAmount)
             )
-            .to.emit(WETHPair, 'Swap')
+            .to.emit(VVETPair, 'Swap')
             .withArgs(
               router.address,
-              WETHPairToken0 === WETHPartner.address ? expectedSwapAmount : 0,
-              WETHPairToken0 === WETHPartner.address ? 0 : expectedSwapAmount,
-              WETHPairToken0 === WETHPartner.address ? 0 : outputAmount,
-              WETHPairToken0 === WETHPartner.address ? outputAmount : 0,
+              VVETPairToken0 === VVETPartner.address ? expectedSwapAmount : 0,
+              VVETPairToken0 === VVETPartner.address ? 0 : expectedSwapAmount,
+              VVETPairToken0 === VVETPartner.address ? 0 : outputAmount,
+              VVETPairToken0 === VVETPartner.address ? outputAmount : 0,
               router.address
             )
         })
 
         it('amounts', async () => {
-          await WETHPartner.approve(routerEventEmitter.address, MaxUint256)
+          await VVETPartner.approve(routerEventEmitter.address, MaxUint256)
           await expect(
-            routerEventEmitter.swapTokensForExactETH(
+            routerEventEmitter.swapTokensForExactVET(
               router.address,
               outputAmount,
               MaxUint256,
-              [WETHPartner.address, WETH.address],
+              [VVETPartner.address, VVET.address],
               wallet.address,
               MaxUint256,
               overrides
@@ -594,64 +594,64 @@ describe('VexchangeV2Router{01,02}', () => {
         })
       })
 
-      describe('swapExactTokensForETH', () => {
-        const WETHPartnerAmount = expandTo18Decimals(5)
-        const ETHAmount = expandTo18Decimals(10)
+      describe('swapExactTokensForVET', () => {
+        const VVETPartnerAmount = expandTo18Decimals(5)
+        const VETAmount = expandTo18Decimals(10)
         const swapAmount = expandTo18Decimals(1)
         const expectedOutputAmount = bigNumberify('1662497915624478906')
 
         beforeEach(async () => {
-          await WETHPartner.transfer(WETHPair.address, WETHPartnerAmount)
-          await WETH.deposit({ value: ETHAmount })
-          await WETH.transfer(WETHPair.address, ETHAmount)
-          await WETHPair.mint(wallet.address, overrides)
+          await VVETPartner.transfer(VVETPair.address, VVETPartnerAmount)
+          await VVET.deposit({ value: VETAmount })
+          await VVET.transfer(VVETPair.address, VETAmount)
+          await VVETPair.mint(wallet.address, overrides)
         })
 
         it('happy path', async () => {
-          await WETHPartner.approve(router.address, MaxUint256)
-          const WETHPairToken0 = await WETHPair.token0()
+          await VVETPartner.approve(router.address, MaxUint256)
+          const VVETPairToken0 = await VVETPair.token0()
           await expect(
-            router.swapExactTokensForETH(
+            router.swapExactTokensForVET(
               swapAmount,
               0,
-              [WETHPartner.address, WETH.address],
+              [VVETPartner.address, VVET.address],
               wallet.address,
               MaxUint256,
               overrides
             )
           )
-            .to.emit(WETHPartner, 'Transfer')
-            .withArgs(wallet.address, WETHPair.address, swapAmount)
-            .to.emit(WETH, 'Transfer')
-            .withArgs(WETHPair.address, router.address, expectedOutputAmount)
-            .to.emit(WETHPair, 'Sync')
+            .to.emit(VVETPartner, 'Transfer')
+            .withArgs(wallet.address, VVETPair.address, swapAmount)
+            .to.emit(VVET, 'Transfer')
+            .withArgs(VVETPair.address, router.address, expectedOutputAmount)
+            .to.emit(VVETPair, 'Sync')
             .withArgs(
-              WETHPairToken0 === WETHPartner.address
-                ? WETHPartnerAmount.add(swapAmount)
-                : ETHAmount.sub(expectedOutputAmount),
-              WETHPairToken0 === WETHPartner.address
-                ? ETHAmount.sub(expectedOutputAmount)
-                : WETHPartnerAmount.add(swapAmount)
+              VVETPairToken0 === VVETPartner.address
+                ? VVETPartnerAmount.add(swapAmount)
+                : VETAmount.sub(expectedOutputAmount),
+              VVETPairToken0 === VVETPartner.address
+                ? VETAmount.sub(expectedOutputAmount)
+                : VVETPartnerAmount.add(swapAmount)
             )
-            .to.emit(WETHPair, 'Swap')
+            .to.emit(VVETPair, 'Swap')
             .withArgs(
               router.address,
-              WETHPairToken0 === WETHPartner.address ? swapAmount : 0,
-              WETHPairToken0 === WETHPartner.address ? 0 : swapAmount,
-              WETHPairToken0 === WETHPartner.address ? 0 : expectedOutputAmount,
-              WETHPairToken0 === WETHPartner.address ? expectedOutputAmount : 0,
+              VVETPairToken0 === VVETPartner.address ? swapAmount : 0,
+              VVETPairToken0 === VVETPartner.address ? 0 : swapAmount,
+              VVETPairToken0 === VVETPartner.address ? 0 : expectedOutputAmount,
+              VVETPairToken0 === VVETPartner.address ? expectedOutputAmount : 0,
               router.address
             )
         })
 
         it('amounts', async () => {
-          await WETHPartner.approve(routerEventEmitter.address, MaxUint256)
+          await VVETPartner.approve(routerEventEmitter.address, MaxUint256)
           await expect(
-            routerEventEmitter.swapExactTokensForETH(
+            routerEventEmitter.swapExactTokensForVET(
               router.address,
               swapAmount,
               0,
-              [WETHPartner.address, WETH.address],
+              [VVETPartner.address, VVET.address],
               wallet.address,
               MaxUint256,
               overrides
@@ -662,25 +662,25 @@ describe('VexchangeV2Router{01,02}', () => {
         })
       })
 
-      describe('swapETHForExactTokens', () => {
-        const WETHPartnerAmount = expandTo18Decimals(10)
-        const ETHAmount = expandTo18Decimals(5)
+      describe('swapVETForExactTokens', () => {
+        const VVETPartnerAmount = expandTo18Decimals(10)
+        const VETAmount = expandTo18Decimals(5)
         const expectedSwapAmount = bigNumberify('557227237267357629')
         const outputAmount = expandTo18Decimals(1)
 
         beforeEach(async () => {
-          await WETHPartner.transfer(WETHPair.address, WETHPartnerAmount)
-          await WETH.deposit({ value: ETHAmount })
-          await WETH.transfer(WETHPair.address, ETHAmount)
-          await WETHPair.mint(wallet.address, overrides)
+          await VVETPartner.transfer(VVETPair.address, VVETPartnerAmount)
+          await VVET.deposit({ value: VETAmount })
+          await VVET.transfer(VVETPair.address, VETAmount)
+          await VVETPair.mint(wallet.address, overrides)
         })
 
         it('happy path', async () => {
-          const WETHPairToken0 = await WETHPair.token0()
+          const VVETPairToken0 = await VVETPair.token0()
           await expect(
-            router.swapETHForExactTokens(
+            router.swapVETForExactTokens(
               outputAmount,
-              [WETH.address, WETHPartner.address],
+              [VVET.address, VVETPartner.address],
               wallet.address,
               MaxUint256,
               {
@@ -689,36 +689,36 @@ describe('VexchangeV2Router{01,02}', () => {
               }
             )
           )
-            .to.emit(WETH, 'Transfer')
-            .withArgs(router.address, WETHPair.address, expectedSwapAmount)
-            .to.emit(WETHPartner, 'Transfer')
-            .withArgs(WETHPair.address, wallet.address, outputAmount)
-            .to.emit(WETHPair, 'Sync')
+            .to.emit(VVET, 'Transfer')
+            .withArgs(router.address, VVETPair.address, expectedSwapAmount)
+            .to.emit(VVETPartner, 'Transfer')
+            .withArgs(VVETPair.address, wallet.address, outputAmount)
+            .to.emit(VVETPair, 'Sync')
             .withArgs(
-              WETHPairToken0 === WETHPartner.address
-                ? WETHPartnerAmount.sub(outputAmount)
-                : ETHAmount.add(expectedSwapAmount),
-              WETHPairToken0 === WETHPartner.address
-                ? ETHAmount.add(expectedSwapAmount)
-                : WETHPartnerAmount.sub(outputAmount)
+              VVETPairToken0 === VVETPartner.address
+                ? VVETPartnerAmount.sub(outputAmount)
+                : VETAmount.add(expectedSwapAmount),
+              VVETPairToken0 === VVETPartner.address
+                ? VETAmount.add(expectedSwapAmount)
+                : VVETPartnerAmount.sub(outputAmount)
             )
-            .to.emit(WETHPair, 'Swap')
+            .to.emit(VVETPair, 'Swap')
             .withArgs(
               router.address,
-              WETHPairToken0 === WETHPartner.address ? 0 : expectedSwapAmount,
-              WETHPairToken0 === WETHPartner.address ? expectedSwapAmount : 0,
-              WETHPairToken0 === WETHPartner.address ? outputAmount : 0,
-              WETHPairToken0 === WETHPartner.address ? 0 : outputAmount,
+              VVETPairToken0 === VVETPartner.address ? 0 : expectedSwapAmount,
+              VVETPairToken0 === VVETPartner.address ? expectedSwapAmount : 0,
+              VVETPairToken0 === VVETPartner.address ? outputAmount : 0,
+              VVETPairToken0 === VVETPartner.address ? 0 : outputAmount,
               wallet.address
             )
         })
 
         it('amounts', async () => {
           await expect(
-            routerEventEmitter.swapETHForExactTokens(
+            routerEventEmitter.swapVETForExactTokens(
               router.address,
               outputAmount,
-              [WETH.address, WETHPartner.address],
+              [VVET.address, VVETPartner.address],
               wallet.address,
               MaxUint256,
               {

--- a/uniswap-v2-periphery/test/VexchangeV2Router01.spec.ts
+++ b/uniswap-v2-periphery/test/VexchangeV2Router01.spec.ts
@@ -370,8 +370,8 @@ describe('VexchangeV2Router{01,02}', () => {
           const receipt = await tx.wait()
           expect(receipt.gasUsed).to.eq(
             {
-              [RouterVersion.VexchangeV2Router01]: 96903,
-              [RouterVersion.VexchangeV2Router02]: 96925
+              [RouterVersion.VexchangeV2Router01]: 96880,
+              [RouterVersion.VexchangeV2Router02]: 96881
             }[routerVersion as RouterVersion]
           )
         }).retries(3)
@@ -517,13 +517,15 @@ describe('VexchangeV2Router{01,02}', () => {
             }
           )
           const receipt = await tx.wait()
-          expect(receipt.gasUsed).to.eq(
-            {
-              [RouterVersion.VexchangeV2Router01]: 131685,
-              [RouterVersion.VexchangeV2Router02]: 131685
-            }[routerVersion as RouterVersion]
-          )
-        }).retries(3)
+          expect(receipt.gasUsed).to.satisfy( function(gas: number) {
+            if (routerVersion == RouterVersion.VexchangeV2Router01) {
+              return ((gas==131686))
+            }
+            else if (routerVersion == RouterVersion.VexchangeV2Router02) {
+              return ((gas==101709 || gas==131709))
+            }
+          })
+        })
       })
 
       describe('swapTokensForExactVET', () => {

--- a/uniswap-v2-periphery/test/shared/fixtures.ts
+++ b/uniswap-v2-periphery/test/shared/fixtures.ts
@@ -8,7 +8,7 @@ import VexchangeV2Factory from '../../../uniswap-v2-core/build/VexchangeV2Factor
 import IVexchangeV2Pair from '../../../uniswap-v2-core/build/IVexchangeV2Pair.json'
 
 import ERC20 from '../../build/ERC20.json'
-import WETH9 from '../../build/WETH9.json'
+import VVET9 from '../../build/VVET9.json'
 import VexchangeV1Exchange from '../../build/VexchangeV1Exchange.json'
 import VexchangeV1Factory from '../../build/VexchangeV1Factory.json'
 import VexchangeV2Router01 from '../../build/VexchangeV2Router01.json'
@@ -23,8 +23,8 @@ const overrides = {
 interface V2Fixture {
   token0: Contract
   token1: Contract
-  WETH: Contract
-  WETHPartner: Contract
+  VVET: Contract
+  VVETPartner: Contract
   factoryV1: Contract
   factoryV2: Contract
   router01: Contract
@@ -32,9 +32,9 @@ interface V2Fixture {
   routerEventEmitter: Contract
   router: Contract
   migrator: Contract
-  WETHExchangeV1: Contract
+  VVETExchangeV1: Contract
   pair: Contract
-  WETHPair: Contract
+  VVETPair: Contract
 }
 
 export async function v2Fixture(provider: Web3Provider, [wallet]: Wallet[]): Promise<V2Fixture> {
@@ -42,8 +42,8 @@ export async function v2Fixture(provider: Web3Provider, [wallet]: Wallet[]): Pro
   // deploy tokens
   const tokenA = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)])
   const tokenB = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)])
-  const WETH = await deployContract(wallet, WETH9)
-  const WETHPartner = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)])
+  const VVET = await deployContract(wallet, VVET9)
+  const VVETPartner = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)])
 
   // deploy V1
   const factoryV1 = await deployContract(wallet, VexchangeV1Factory, [])
@@ -55,8 +55,8 @@ export async function v2Fixture(provider: Web3Provider, [wallet]: Wallet[]): Pro
   const factoryV2 = await deployContract(wallet, VexchangeV2Factory, [defaultSwapFee, defaultPlatformFee, wallet.address], overrides)
 
   // deploy routers
-  const router01 = await deployContract(wallet, VexchangeV2Router01, [factoryV2.address, WETH.address], overrides)
-  const router02 = await deployContract(wallet, VexchangeV2Router02, [factoryV2.address, WETH.address], overrides)
+  const router01 = await deployContract(wallet, VexchangeV2Router01, [factoryV2.address, VVET.address], overrides)
+  const router02 = await deployContract(wallet, VexchangeV2Router02, [factoryV2.address, VVET.address], overrides)
 
   // event emitter for testing
   const routerEventEmitter = await deployContract(wallet, RouterEventEmitter, [])
@@ -65,9 +65,9 @@ export async function v2Fixture(provider: Web3Provider, [wallet]: Wallet[]): Pro
   const migrator = await deployContract(wallet, VexchangeV2Migrator, [factoryV1.address, router01.address], overrides)
 
   // initialize V1
-  await factoryV1.createExchange(WETHPartner.address, overrides)
-  const WETHExchangeV1Address = await factoryV1.getExchange(WETHPartner.address)
-  const WETHExchangeV1 = new Contract(WETHExchangeV1Address, JSON.stringify(VexchangeV1Exchange.abi), provider).connect(
+  await factoryV1.createExchange(VVETPartner.address, overrides)
+  const VVETExchangeV1Address = await factoryV1.getExchange(VVETPartner.address)
+  const VVETExchangeV1 = new Contract(VVETExchangeV1Address, JSON.stringify(VexchangeV1Exchange.abi), provider).connect(
     wallet
   )
 
@@ -80,15 +80,15 @@ export async function v2Fixture(provider: Web3Provider, [wallet]: Wallet[]): Pro
   const token0 = tokenA.address === token0Address ? tokenA : tokenB
   const token1 = tokenA.address === token0Address ? tokenB : tokenA
 
-  await factoryV2.createPair(WETH.address, WETHPartner.address)
-  const WETHPairAddress = await factoryV2.getPair(WETH.address, WETHPartner.address)
-  const WETHPair = new Contract(WETHPairAddress, JSON.stringify(IVexchangeV2Pair.abi), provider).connect(wallet)
+  await factoryV2.createPair(VVET.address, VVETPartner.address)
+  const VVETPairAddress = await factoryV2.getPair(VVET.address, VVETPartner.address)
+  const VVETPair = new Contract(VVETPairAddress, JSON.stringify(IVexchangeV2Pair.abi), provider).connect(wallet)
 
   return {
     token0,
     token1,
-    WETH,
-    WETHPartner,
+    VVET,
+    VVETPartner,
     factoryV1,
     factoryV2,
     router01,
@@ -96,8 +96,8 @@ export async function v2Fixture(provider: Web3Provider, [wallet]: Wallet[]): Pro
     router: router02, // the default router, 01 had a minor bug
     routerEventEmitter,
     migrator,
-    WETHExchangeV1,
+    VVETExchangeV1,
     pair,
-    WETHPair
+    VVETPair
   }
 }


### PR DESCRIPTION
1. Regarding the VVET contract in contracts/test
- I know we're probably not going to be using this version in the end as the new vvet is coming out soon, but it's still good to document some things. 
- Adapted it from a byte ahead's `VVET9.sol`. Enabled (uncommented) the fallback receive function. Upgraded the solidity version to 0.6.6
- The IVVET interface is exactly the same as the IWETH interface

2. Did not change ETH references for VexchangeV1 related code, since the interface was written that way. So in files that use the v1 interface, like `ExampleFlashSwap.sol`, some references to ETH are intact.

3. Also renamed the ETH references to VET in the TransferHelper class

4. All tests are passing, except for those that involve gas cost. The expected gas values in 5 test cases are off by a few gas. In the original code I noticed that the uniswap devs commented that the gas tests are inconsistent. We can either:
- modify the expected gas value 
- remove the gas test altogether 

I think the first choice of modifying the expected gas value makes more sense. In case there are any unexpected changes that break it in the future. Any thoughts? 