### PR TITLE
Changed implementation of computeLiquidityValue, computeProfitMaximizingTrade, getAmountIn, getAmountOut to cater for variable swapFee and platformFee

### DIFF
--- a/uniswap-v2-core/test/VexchangeV2Pair.spec.ts
+++ b/uniswap-v2-core/test/VexchangeV2Pair.spec.ts
@@ -408,7 +408,7 @@ describe('VexchangeV2Pair', () => {
       return verifyGas( gas, [159865, 119049], "Burn gas cost" );
     })
     
-    // Expected fee @ 1/6 or 0.1667% is calculated at 249800449363715 which is a ~0.02% error off the original uniswap.
+    // Expected fee @ 1/6 or 16.67% is calculated at 249800449363715 which is a ~0.02% error off the original uniswap.
     // (Original uniswap v2 equivalent ==> 249750499251388)
     const expectedPlatformFee: BigNumber = bigNumberify(249800449363715)
 
@@ -428,13 +428,13 @@ describe('VexchangeV2Pair', () => {
     const minInverseVariance: number = targetInverseVariance * 0.95;
     const maxInverseVariance: number = targetInverseVariance * 1.05;
 
-    // Compare 1/6 vexchangeV2 fee, using 0.1667 Vexchange Platform fee: run check to confirm ~ 0.02% variance.
+    // Compare 1/6 vexchangeV2 fee, using 1667 bp Vexchange Platform fee: run check to confirm ~ 0.02% variance.
     const token0ExpBalVexchangeV2: BigNumber = bigNumberify( '249501683697445' )
     const token0ExpBalVexchange: BigNumber = bigNumberify( '249551584034184' )
     const token0Variance: number = token0ExpBalVexchangeV2.div(token0ExpBalVexchange.sub(token0ExpBalVexchangeV2)).toNumber();
     expect(token0Variance, "token 0 variance from uniswap v2 fee" ).to.be.within(minInverseVariance, maxInverseVariance)
 
-    // Compare 1/6 vexchangeV2 fee, using 0.1667 Vexchange Platform fee: run check to confirm ~ 0.02% variance.
+    // Compare 1/6 vexchangeV2 fee, using 1667 bp Vexchange Platform fee: run check to confirm ~ 0.02% variance.
     const token1ExpBalVexchangeV2: BigNumber = bigNumberify( '250000187312969' )
     const token1ExpBalVexchange: BigNumber = bigNumberify( '250050187350431' )
     const token1Variance: number = token1ExpBalVexchangeV2.div(token1ExpBalVexchange.sub(token1ExpBalVexchangeV2)).toNumber();

--- a/uniswap-v2-core/test/VexchangeV2Pair.spec.ts
+++ b/uniswap-v2-core/test/VexchangeV2Pair.spec.ts
@@ -449,8 +449,34 @@ describe('VexchangeV2Pair', () => {
   /**
    * calcPlatformFee
    * 
-   * Note that this function is deliberately verbose.
+   * Note that this function is deliberately verbose, implementing the Pair contract's platform-fee calculation, with
+   * additional assertion validation.
    * 
+   * This function is used in further tests below, to verify correct operation of the fee calculations in  the contract transactions.
+   * 
+   * Test Strategy
+   * =============
+   *  - Rely on the mathematically proven fact that the implemented platformFee is mathematically equivalent to the Uniswap general 
+   *    equation for fees (for this equation, see whitepaper, equation 6);
+   *  - Implement the platformFee calculation in javascript, in order to use it to verify the contract transaction values;
+   *  - Prove the javascript implementation by pre-calculated and manually confirmed values;
+   *  - Use the javascript implementation to verify swap and burn transactions, verifying correct fees.
+   * 
+   * Details
+   * =======
+   * The javascript implementation of the contract's platform fee calculation is found in this function is a direct copy of the 
+   * contract implementation with additional assertions around assumptions made for the contract, but that are not included in 
+   * the contract to minimise gas cost.
+   * 
+   * Note that the function calcPlatformFeeUniswap() is a direct implementation of the Uniswap whitepaper equation 6, and implemented
+   * with floating point not integer arithmetic for additional cross-validation. compareCalcPlatformFee proves that the results of
+   * this equation are equivalent, assuming integer ( floor() ) rounding.
+   * 
+   * The tests calcPlatformFeeTestCases confirm that the calcPlatformFee function produce expected results over a range of values - 
+   * with pre calculated expected values.
+   * 
+   * The tests in platformFeeRange then iterate over a transaction involving a specific swap then burn, verifying final total supply and 
+   * balances are as expected, based on expected fees per the calcPlatformFee() function.
    */
   function calcPlatformFee( aPlatformFee: BigNumber,
                             aToken0Balance: BigNumber, aToken1Balance: BigNumber,

--- a/uniswap-v2-periphery/contracts/VexchangeV2Router01.sol
+++ b/uniswap-v2-periphery/contracts/VexchangeV2Router01.sol
@@ -263,12 +263,12 @@ contract VexchangeV2Router01 is IVexchangeV2Router01 {
         return VexchangeV2Library.quote(amountA, reserveA, reserveB);
     }
 
-    function getAmountOut(uint amountIn, uint reserveIn, uint reserveOut) public pure override returns (uint amountOut) {
-        return VexchangeV2Library.getAmountOut(amountIn, reserveIn, reserveOut);
+    function getAmountOut(uint amountIn, uint reserveIn, uint reserveOut, uint swapFee) public pure override returns (uint amountOut) {
+        return VexchangeV2Library.getAmountOut(amountIn, reserveIn, reserveOut, swapFee);
     }
 
-    function getAmountIn(uint amountOut, uint reserveIn, uint reserveOut) public pure override returns (uint amountIn) {
-        return VexchangeV2Library.getAmountOut(amountOut, reserveIn, reserveOut);
+    function getAmountIn(uint amountOut, uint reserveIn, uint reserveOut, uint swapFee) public pure override returns (uint amountIn) {
+        return VexchangeV2Library.getAmountOut(amountOut, reserveIn, reserveOut, swapFee);
     }
 
     function getAmountsOut(uint amountIn, address[] memory path) public view override returns (uint[] memory amounts) {

--- a/uniswap-v2-periphery/contracts/VexchangeV2Router02.sol
+++ b/uniswap-v2-periphery/contracts/VexchangeV2Router02.sol
@@ -329,7 +329,7 @@ contract VexchangeV2Router02 is IVexchangeV2Router02 {
             (uint reserve0, uint reserve1,) = pair.getReserves();
             (uint reserveInput, uint reserveOutput) = input == token0 ? (reserve0, reserve1) : (reserve1, reserve0);
             amountInput = IERC20(input).balanceOf(address(pair)).sub(reserveInput);
-            amountOutput = VexchangeV2Library.getAmountOut(amountInput, reserveInput, reserveOutput);
+            amountOutput = VexchangeV2Library.getAmountOut(amountInput, reserveInput, reserveOutput, pair.swapFee());
             }
             (uint amount0Out, uint amount1Out) = input == token0 ? (uint(0), amountOutput) : (amountOutput, uint(0));
             address to = i < path.length - 2 ? VexchangeV2Library.pairFor(factory, output, path[i + 2]) : _to;
@@ -404,24 +404,24 @@ contract VexchangeV2Router02 is IVexchangeV2Router02 {
         return VexchangeV2Library.quote(amountA, reserveA, reserveB);
     }
 
-    function getAmountOut(uint amountIn, uint reserveIn, uint reserveOut)
+    function getAmountOut(uint amountIn, uint reserveIn, uint reserveOut, uint swapFee)
         public
         pure
         virtual
         override
         returns (uint amountOut)
     {
-        return VexchangeV2Library.getAmountOut(amountIn, reserveIn, reserveOut);
+        return VexchangeV2Library.getAmountOut(amountIn, reserveIn, reserveOut, swapFee);
     }
 
-    function getAmountIn(uint amountOut, uint reserveIn, uint reserveOut)
+    function getAmountIn(uint amountOut, uint reserveIn, uint reserveOut, uint swapFee)
         public
         pure
         virtual
         override
         returns (uint amountIn)
     {
-        return VexchangeV2Library.getAmountIn(amountOut, reserveIn, reserveOut);
+        return VexchangeV2Library.getAmountIn(amountOut, reserveIn, reserveOut, swapFee);
     }
 
     function getAmountsOut(uint amountIn, address[] memory path)

--- a/uniswap-v2-periphery/contracts/examples/ExampleSwapToPrice.sol
+++ b/uniswap-v2-periphery/contracts/examples/ExampleSwapToPrice.sol
@@ -46,7 +46,8 @@ contract ExampleSwapToPrice {
             uint swapFee = IVexchangeV2Pair(VexchangeV2Library.pairFor(factory, tokenA, tokenB)).swapFee();
             (aToB, amountIn) = VexchangeV2LiquidityMathLibrary.computeProfitMaximizingTrade(
                 truePriceTokenA, truePriceTokenB,
-                reserveA, reserveB, swapFee
+                reserveA, reserveB, 
+                swapFee
             );
         }
 

--- a/uniswap-v2-periphery/contracts/examples/ExampleSwapToPrice.sol
+++ b/uniswap-v2-periphery/contracts/examples/ExampleSwapToPrice.sol
@@ -43,9 +43,10 @@ contract ExampleSwapToPrice {
         uint256 amountIn;
         {
             (uint256 reserveA, uint256 reserveB) = VexchangeV2Library.getReserves(factory, tokenA, tokenB);
+            uint swapFee = IVexchangeV2Pair(VexchangeV2Library.pairFor(factory, tokenA, tokenB)).swapFee();
             (aToB, amountIn) = VexchangeV2LiquidityMathLibrary.computeProfitMaximizingTrade(
                 truePriceTokenA, truePriceTokenB,
-                reserveA, reserveB
+                reserveA, reserveB, swapFee
             );
         }
 

--- a/uniswap-v2-periphery/contracts/interfaces/IVexchangeV2Router01.sol
+++ b/uniswap-v2-periphery/contracts/interfaces/IVexchangeV2Router01.sol
@@ -88,8 +88,8 @@ interface IVexchangeV2Router01 {
         returns (uint[] memory amounts);
 
     function quote(uint amountA, uint reserveA, uint reserveB) external pure returns (uint amountB);
-    function getAmountOut(uint amountIn, uint reserveIn, uint reserveOut) external pure returns (uint amountOut);
-    function getAmountIn(uint amountOut, uint reserveIn, uint reserveOut) external pure returns (uint amountIn);
+    function getAmountOut(uint amountIn, uint reserveIn, uint reserveOut, uint swapFee) external pure returns (uint amountOut);
+    function getAmountIn(uint amountOut, uint reserveIn, uint reserveOut, uint swapFee) external pure returns (uint amountIn);
     function getAmountsOut(uint amountIn, address[] calldata path) external view returns (uint[] memory amounts);
     function getAmountsIn(uint amountOut, address[] calldata path) external view returns (uint[] memory amounts);
 }

--- a/uniswap-v2-periphery/contracts/libraries/VexchangeV2Library.sol
+++ b/uniswap-v2-periphery/contracts/libraries/VexchangeV2Library.sol
@@ -28,8 +28,7 @@ library VexchangeV2Library {
     }
     
     function getSwapFee(address factory, address tokenA, address tokenB) internal view returns (uint swapFee) {
-        (address token0, address token1) = sortTokens(tokenA, tokenB);
-        swapFee = IVexchangeV2Pair(pairFor(factory, token0, token1)).swapFee();
+        swapFee = IVexchangeV2Pair(pairFor(factory, tokenA, tokenB)).swapFee();
     }
 
     // fetches and sorts the reserves for a pair
@@ -73,7 +72,8 @@ library VexchangeV2Library {
         for (uint i; i < path.length - 1; i++) {
             (uint reserveIn, uint reserveOut) = getReserves(factory, path[i], path[i + 1]);
             uint swapFee = getSwapFee(factory, path[i], path[i + 1]);
-            amounts[i + 1] = getAmountOut(amounts[i], reserveIn, reserveOut, swapFee);        }
+            amounts[i + 1] = getAmountOut(amounts[i], reserveIn, reserveOut, swapFee);        
+        }
     }
 
     // performs chained getAmountIn calculations on any number of pairs
@@ -84,6 +84,7 @@ library VexchangeV2Library {
         for (uint i = path.length - 1; i > 0; i--) {
             (uint reserveIn, uint reserveOut) = getReserves(factory, path[i - 1], path[i]);
             uint swapFee = getSwapFee(factory, path[i - 1], path[i]);
-            amounts[i - 1] = getAmountIn(amounts[i], reserveIn, reserveOut, swapFee);        }
+            amounts[i - 1] = getAmountIn(amounts[i], reserveIn, reserveOut, swapFee);        
+        }
     }
 }

--- a/uniswap-v2-periphery/contracts/libraries/VexchangeV2LiquidityMathLibrary.sol
+++ b/uniswap-v2-periphery/contracts/libraries/VexchangeV2LiquidityMathLibrary.sol
@@ -15,7 +15,7 @@ library VexchangeV2LiquidityMathLibrary {
 
     uint256 public constant ACCURACY         = 10e37;
     uint256 public constant SQUARED_ACCURACY = 10e75;
-    uint256 public constant FEE_ACCURACY     = 10_000;    
+    uint256 public constant FEE_ACCURACY     = 10_000;
 
     // computes the direction and magnitude of the profit-maximizing trade
     function computeProfitMaximizingTrade(
@@ -91,8 +91,8 @@ library VexchangeV2LiquidityMathLibrary {
             uint rootK = Babylonian.sqrt(reservesA.mul(reservesB));
             uint rootKLast = Babylonian.sqrt(kLast);
             if (rootK > rootKLast) {
-                uint256 _scaledGrowth = rootK.mul(ACCURACY) / rootKLast;                         // ASSERT: < UINT256
-                uint256 _scaledMultiplier = ACCURACY.sub(SQUARED_ACCURACY / _scaledGrowth);          // ASSERT: < UINT128
+                uint256 _scaledGrowth = rootK.mul(ACCURACY) / rootKLast;                            // ASSERT: < UINT256
+                uint256 _scaledMultiplier = ACCURACY.sub(SQUARED_ACCURACY / _scaledGrowth);         // ASSERT: < UINT128
                 uint256 _scaledTargetOwnership = _scaledMultiplier.mul(platformFee) / FEE_ACCURACY; // ASSERT: < UINT144 during maths, ends < UINT128
                 uint feeLiquidity = _scaledTargetOwnership.mul(totalSupply) / ACCURACY.sub(_scaledTargetOwnership); // ASSERT: _scaledTargetOwnership < ACCURACY
                 totalSupply = totalSupply.add(feeLiquidity);

--- a/uniswap-v2-periphery/contracts/libraries/VexchangeV2LiquidityMathLibrary.sol
+++ b/uniswap-v2-periphery/contracts/libraries/VexchangeV2LiquidityMathLibrary.sol
@@ -88,16 +88,17 @@ library VexchangeV2LiquidityMathLibrary {
         uint kLast
     ) internal pure returns (uint256 tokenAAmount, uint256 tokenBAmount) {
         if (platformFee > 0 && kLast > 0) {
-            uint rootK = Babylonian.sqrt(reservesA.mul(reservesB));
-            uint rootKLast = Babylonian.sqrt(kLast);
-            if (rootK > rootKLast) {
-                uint256 _scaledGrowth = rootK.mul(ACCURACY) / rootKLast;                            // ASSERT: < UINT256
-                uint256 _scaledMultiplier = ACCURACY.sub(SQUARED_ACCURACY / _scaledGrowth);         // ASSERT: < UINT128
-                uint256 _scaledTargetOwnership = _scaledMultiplier.mul(platformFee) / FEE_ACCURACY; // ASSERT: < UINT144 during maths, ends < UINT128
-                uint feeLiquidity = _scaledTargetOwnership.mul(totalSupply) / ACCURACY.sub(_scaledTargetOwnership); // ASSERT: _scaledTargetOwnership < ACCURACY
+            uint sqrtNewK = Babylonian.sqrt(reservesA.mul(reservesB));
+            uint sqrtOldK = Babylonian.sqrt(kLast);
+            if (sqrtNewK > sqrtOldK) {
+                uint256 _scaledGrowth = sqrtNewK.mul(ACCURACY) / sqrtOldK;                            
+                uint256 _scaledMultiplier = ACCURACY.sub(SQUARED_ACCURACY / _scaledGrowth);         
+                uint256 _scaledTargetOwnership = _scaledMultiplier.mul(platformFee) / FEE_ACCURACY; 
+                
+                uint feeLiquidity = _scaledTargetOwnership.mul(totalSupply) / ACCURACY.sub(_scaledTargetOwnership); 
                 totalSupply = totalSupply.add(feeLiquidity);
             }
-        } 
+        }
         return (reservesA.mul(liquidityAmount) / totalSupply, reservesB.mul(liquidityAmount) / totalSupply);
     }
 

--- a/uniswap-v2-periphery/test/ExampleComputeLiquidityValue.spec.ts
+++ b/uniswap-v2-periphery/test/ExampleComputeLiquidityValue.spec.ts
@@ -97,7 +97,7 @@ describe('ExampleComputeLiquidityValue', () => {
 
     describe('fee on', () => {
       beforeEach('turn on fee', async () => {
-        // Set platform fee to 0.1667%, approx. equivalent to uniswap-V2 (1/6)
+        // Set platform fee to 16.67%, approx. equivalent to uniswap-V2 (1/6)
         await factory.setPlatformFeeForPair( pair.address, 1667 );
       })
 
@@ -124,8 +124,8 @@ describe('ExampleComputeLiquidityValue', () => {
           token1.address,
           expandTo18Decimals(7)
         )
-        expect(token0Amount).to.eq('1399824934325735058')
-        expect(token1Amount).to.eq('35048195651620807684')
+        expect(token0Amount).to.eq('1399824899312600205')
+        expect(token1Amount).to.eq('35048194774977471355')
       })
     })
   })
@@ -324,7 +324,7 @@ describe('ExampleComputeLiquidityValue', () => {
 
     describe('fee is on', () => {
       beforeEach('turn on fee', async () => {
-        // Set platform fee to 0.1667%, approx. equivalent to uniswap-V2 (1/6)
+        // Set platform fee to 16.67%, approx. equivalent to uniswap-V2 (1/6)
         await factory.setPlatformFeeForPair( pair.address, 1667 );
       })
 
@@ -345,8 +345,8 @@ describe('ExampleComputeLiquidityValue', () => {
             105,
             expandTo18Decimals(5)
           )
-          expect(token0Amount).to.eq('488680839243189328') // slightly less than 5% of 10, or 0.5
-          expect(token1Amount).to.eq('51161037620273529068') // slightly more than 5% of 100, or 5
+          expect(token0Amount).to.eq('488680838688540313') // slightly less than 5% of 10, or 0.5
+          expect(token1Amount).to.eq('51161037562206142622') // slightly more than 5% of 100, or 5
         })
 
         it('produces the correct value after arbing to 1:95', async () => {
@@ -357,8 +357,8 @@ describe('ExampleComputeLiquidityValue', () => {
             95,
             expandTo18Decimals(5)
           )
-          expect(token0Amount).to.eq('512252817918759166') // slightly more than 5% of 10, or 0.5
-          expect(token1Amount).to.eq('48806945633721895174') // slightly less than 5% of 100, or 5
+          expect(token0Amount).to.eq('512252817305954073') // slightly more than 5% of 10, or 0.5
+          expect(token1Amount).to.eq('48806945575334427424') // slightly less than 5% of 100, or 5
         })
 
         it('produces correct value at the current price', async () => {
@@ -435,8 +435,8 @@ describe('ExampleComputeLiquidityValue', () => {
             expandTo18Decimals(5)
           )
 
-          expect(token0Amount).to.eq('999874953089810756')
-          expect(token1Amount).to.eq('25034425465443434060')
+          expect(token0Amount).to.eq('999874928080428718')
+          expect(token1Amount).to.eq('25034424839269622396')
         })
 
         it('shares after arbing back to 1:100', async () => {
@@ -448,8 +448,8 @@ describe('ExampleComputeLiquidityValue', () => {
             expandTo18Decimals(5)
           )
 
-          expect(token0Amount).to.eq('501002443792372662')
-          expect(token1Amount).to.eq('50024924521757597314')
+          expect(token0Amount).to.eq('501002418745423792')
+          expect(token1Amount).to.eq('50024922020828226126')
         })
       })
     })

--- a/uniswap-v2-periphery/test/ExampleComputeLiquidityValue.spec.ts
+++ b/uniswap-v2-periphery/test/ExampleComputeLiquidityValue.spec.ts
@@ -204,7 +204,7 @@ describe('ExampleComputeLiquidityValue', () => {
     })
   })
 
-  describe('#getLiquidityValue', () => {
+  describe('#getLiquidityValueAfterArbitrageToPrice', () => {
     describe('fee is off', () => {
       it('produces the correct value after arbing to 1:105', async () => {
         const [token0Amount, token1Amount] = await computeLiquidityValue.getLiquidityValueAfterArbitrageToPrice(
@@ -251,7 +251,7 @@ describe('ExampleComputeLiquidityValue', () => {
             100,
             expandTo18Decimals(5)
           )
-        ).to.eq('13869')
+        ).to.eq('13684')
       })
 
       it('gas higher price', async () => {
@@ -263,7 +263,7 @@ describe('ExampleComputeLiquidityValue', () => {
             105,
             expandTo18Decimals(5)
           )
-        ).to.eq('14656')
+        ).to.eq('14471')
       })
 
       it('gas lower price', async () => {
@@ -275,7 +275,7 @@ describe('ExampleComputeLiquidityValue', () => {
             95,
             expandTo18Decimals(5)
           )
-        ).to.eq('14701')
+        ).to.eq('14516')
       })
 
       describe('after a swap', () => {
@@ -383,7 +383,7 @@ describe('ExampleComputeLiquidityValue', () => {
             100,
             expandTo18Decimals(5)
           )
-        ).to.eq('17481')
+        ).to.eq('17296')
       })
 
       it('gas higher price', async () => {
@@ -395,7 +395,7 @@ describe('ExampleComputeLiquidityValue', () => {
             105,
             expandTo18Decimals(5)
           )
-        ).to.eq('19064')
+        ).to.eq('18879')
       })
 
       it('gas lower price', async () => {
@@ -407,7 +407,7 @@ describe('ExampleComputeLiquidityValue', () => {
             95,
             expandTo18Decimals(5)
           )
-        ).to.eq('18995')
+        ).to.eq('18810')
       })
 
       describe('after a swap', () => {

--- a/uniswap-v2-periphery/test/ExampleComputeLiquidityValue.spec.ts
+++ b/uniswap-v2-periphery/test/ExampleComputeLiquidityValue.spec.ts
@@ -195,8 +195,8 @@ describe('ExampleComputeLiquidityValue', () => {
       const [reserveA, reserveB] = await computeLiquidityValue.getReservesAfterArbitrage(
         token0.address,
         token1.address,
-        MaxUint256.div(1000),
-        MaxUint256.div(1000)
+        MaxUint256.div(10000),
+        MaxUint256.div(10000)
       )
       // diff of 30 bips
       expect(reserveA).to.eq('100120248075158403008')

--- a/uniswap-v2-periphery/test/ExampleComputeLiquidityValue.spec.ts
+++ b/uniswap-v2-periphery/test/ExampleComputeLiquidityValue.spec.ts
@@ -251,7 +251,7 @@ describe('ExampleComputeLiquidityValue', () => {
             100,
             expandTo18Decimals(5)
           )
-        ).to.eq('10947')
+        ).to.eq('13869')
       })
 
       it('gas higher price', async () => {
@@ -263,7 +263,7 @@ describe('ExampleComputeLiquidityValue', () => {
             105,
             expandTo18Decimals(5)
           )
-        ).to.eq('11720')
+        ).to.eq('14656')
       })
 
       it('gas lower price', async () => {
@@ -275,7 +275,7 @@ describe('ExampleComputeLiquidityValue', () => {
             95,
             expandTo18Decimals(5)
           )
-        ).to.eq('11765')
+        ).to.eq('14701')
       })
 
       describe('after a swap', () => {
@@ -383,7 +383,7 @@ describe('ExampleComputeLiquidityValue', () => {
             100,
             expandTo18Decimals(5)
           )
-        ).to.eq('14559')
+        ).to.eq('17481')
       })
 
       it('gas higher price', async () => {
@@ -395,7 +395,7 @@ describe('ExampleComputeLiquidityValue', () => {
             105,
             expandTo18Decimals(5)
           )
-        ).to.eq('16096')
+        ).to.eq('19064')
       })
 
       it('gas lower price', async () => {
@@ -407,7 +407,7 @@ describe('ExampleComputeLiquidityValue', () => {
             95,
             expandTo18Decimals(5)
           )
-        ).to.eq('16027')
+        ).to.eq('18995')
       })
 
       describe('after a swap', () => {

--- a/uniswap-v2-periphery/test/ExampleSwapToPrice.spec.ts
+++ b/uniswap-v2-periphery/test/ExampleSwapToPrice.spec.ts
@@ -193,7 +193,7 @@ describe('ExampleSwapToPrice', () => {
       )
       const receipt = await tx.wait()
       expect(receipt.gasUsed).to.satisfy( function(gas: number) {
-        return verifyGas( gas, [114513, 149772], "Swap gas cost" )
+        return verifyGas( gas, [114513, 155329], "Swap gas cost" )
       }) // gas test is inconsistent
     })
   })

--- a/uniswap-v2-periphery/test/ExampleSwapToPrice.spec.ts
+++ b/uniswap-v2-periphery/test/ExampleSwapToPrice.spec.ts
@@ -193,7 +193,7 @@ describe('ExampleSwapToPrice', () => {
       )
       const receipt = await tx.wait()
       expect(receipt.gasUsed).to.satisfy( function(gas: number) {
-        return verifyGas( gas, [114698, 149772], "Swap gas cost" );
+        return verifyGas( gas, [114513, 149772], "Swap gas cost" )
       }) // gas test is inconsistent
     })
   })

--- a/uniswap-v2-periphery/test/ExampleSwapToPrice.spec.ts
+++ b/uniswap-v2-periphery/test/ExampleSwapToPrice.spec.ts
@@ -4,7 +4,7 @@ import { MaxUint256 } from 'ethers/constants'
 import { BigNumber, bigNumberify, defaultAbiCoder, formatEther } from 'ethers/utils'
 import { solidity, MockProvider, createFixtureLoader, deployContract } from 'ethereum-waffle'
 
-import { expandTo18Decimals } from './shared/utilities'
+import { expandTo18Decimals, verifyGas } from './shared/utilities'
 import { v2Fixture } from './shared/fixtures'
 
 import ExampleSwapToPrice from '../build/ExampleSwapToPrice.json'
@@ -193,7 +193,7 @@ describe('ExampleSwapToPrice', () => {
       )
       const receipt = await tx.wait()
       expect(receipt.gasUsed).to.satisfy( function(gas: number) {
-        return ((gas==108906  || gas==149722))
+        return verifyGas( gas, [114698, 149772], "Swap gas cost" );
       }) // gas test is inconsistent
     })
   })

--- a/uniswap-v2-periphery/test/VexchangeV2Router01.spec.ts
+++ b/uniswap-v2-periphery/test/VexchangeV2Router01.spec.ts
@@ -370,8 +370,8 @@ describe('VexchangeV2Router{01,02}', () => {
           const receipt = await tx.wait()
           expect(receipt.gasUsed).to.eq(
             {
-              [RouterVersion.VexchangeV2Router01]: 96880,
-              [RouterVersion.VexchangeV2Router02]: 96881
+              [RouterVersion.VexchangeV2Router01]: 99936,
+              [RouterVersion.VexchangeV2Router02]: 99958
             }[routerVersion as RouterVersion]
           )
         }).retries(3)
@@ -519,10 +519,10 @@ describe('VexchangeV2Router{01,02}', () => {
           const receipt = await tx.wait()
           expect(receipt.gasUsed).to.satisfy( function(gas: number) {
             if (routerVersion == RouterVersion.VexchangeV2Router01) {
-              return verifyGas(gas, [131686], "swapExactVETForTokens Router01");
+              return verifyGas(gas, [104707, 134707], "swapExactVETForTokens Router01");
             }
             else if (routerVersion == RouterVersion.VexchangeV2Router02) {
-              return verifyGas(gas, [101709, 131709], "swapExactVETForTokens Router02");
+              return verifyGas(gas, [104730, 134730], "swapExactVETForTokens Router02");
             }
           })
         })

--- a/uniswap-v2-periphery/test/VexchangeV2Router01.spec.ts
+++ b/uniswap-v2-periphery/test/VexchangeV2Router01.spec.ts
@@ -370,8 +370,8 @@ describe('VexchangeV2Router{01,02}', () => {
           const receipt = await tx.wait()
           expect(receipt.gasUsed).to.eq(
             {
-              [RouterVersion.VexchangeV2Router01]: 99936,
-              [RouterVersion.VexchangeV2Router02]: 99958
+              [RouterVersion.VexchangeV2Router01]: 99751,
+              [RouterVersion.VexchangeV2Router02]: 99773
             }[routerVersion as RouterVersion]
           )
         }).retries(3)
@@ -519,10 +519,10 @@ describe('VexchangeV2Router{01,02}', () => {
           const receipt = await tx.wait()
           expect(receipt.gasUsed).to.satisfy( function(gas: number) {
             if (routerVersion == RouterVersion.VexchangeV2Router01) {
-              return verifyGas(gas, [104707, 134707], "swapExactVETForTokens Router01");
+              return verifyGas(gas, [104522, 134522], "swapExactVETForTokens Router01");
             }
             else if (routerVersion == RouterVersion.VexchangeV2Router02) {
-              return verifyGas(gas, [104730, 134730], "swapExactVETForTokens Router02");
+              return verifyGas(gas, [104545, 134545], "swapExactVETForTokens Router02");
             }
           })
         })

--- a/uniswap-v2-periphery/test/VexchangeV2Router02.spec.ts
+++ b/uniswap-v2-periphery/test/VexchangeV2Router02.spec.ts
@@ -51,27 +51,27 @@ describe('VexchangeV2Router02', () => {
   })
 
   it('getAmountOut', async () => {
-    expect(await router.getAmountOut(bigNumberify(2), bigNumberify(100), bigNumberify(100))).to.eq(bigNumberify(1))
-    await expect(router.getAmountOut(bigNumberify(0), bigNumberify(100), bigNumberify(100))).to.be.revertedWith(
+    expect(await router.getAmountOut(bigNumberify(2), bigNumberify(100), bigNumberify(100), bigNumberify(30))).to.eq(bigNumberify(1))
+    await expect(router.getAmountOut(bigNumberify(0), bigNumberify(100), bigNumberify(100), bigNumberify(30))).to.be.revertedWith(
       'VexchangeV2Library: INSUFFICIENT_INPUT_AMOUNT'
     )
-    await expect(router.getAmountOut(bigNumberify(2), bigNumberify(0), bigNumberify(100))).to.be.revertedWith(
+    await expect(router.getAmountOut(bigNumberify(2), bigNumberify(0), bigNumberify(100), bigNumberify(30))).to.be.revertedWith(
       'VexchangeV2Library: INSUFFICIENT_LIQUIDITY'
     )
-    await expect(router.getAmountOut(bigNumberify(2), bigNumberify(100), bigNumberify(0))).to.be.revertedWith(
+    await expect(router.getAmountOut(bigNumberify(2), bigNumberify(100), bigNumberify(0), bigNumberify(30))).to.be.revertedWith(
       'VexchangeV2Library: INSUFFICIENT_LIQUIDITY'
     )
   })
 
   it('getAmountIn', async () => {
-    expect(await router.getAmountIn(bigNumberify(1), bigNumberify(100), bigNumberify(100))).to.eq(bigNumberify(2))
-    await expect(router.getAmountIn(bigNumberify(0), bigNumberify(100), bigNumberify(100))).to.be.revertedWith(
+    expect(await router.getAmountIn(bigNumberify(1), bigNumberify(100), bigNumberify(100), bigNumberify(30))).to.eq(bigNumberify(2))
+    await expect(router.getAmountIn(bigNumberify(0), bigNumberify(100), bigNumberify(100), bigNumberify(30))).to.be.revertedWith(
       'VexchangeV2Library: INSUFFICIENT_OUTPUT_AMOUNT'
     )
-    await expect(router.getAmountIn(bigNumberify(1), bigNumberify(0), bigNumberify(100))).to.be.revertedWith(
+    await expect(router.getAmountIn(bigNumberify(1), bigNumberify(0), bigNumberify(100), bigNumberify(30))).to.be.revertedWith(
       'VexchangeV2Library: INSUFFICIENT_LIQUIDITY'
     )
-    await expect(router.getAmountIn(bigNumberify(1), bigNumberify(100), bigNumberify(0))).to.be.revertedWith(
+    await expect(router.getAmountIn(bigNumberify(1), bigNumberify(100), bigNumberify(0), bigNumberify(30))).to.be.revertedWith(
       'VexchangeV2Library: INSUFFICIENT_LIQUIDITY'
     )
   })


### PR DESCRIPTION
So I basically copied the implementation for _calcFee over to computeLiquidityValue like Oliver suggested. 

But the test cases involving platformFee are failing. The numbers are off by a little, in the 10e-6% kind of range. I went through all the relevant code a few times, but I think that my copied implementation should be correct. So I can't tell if the deviation shown in the test cases are a result of the accuracy scalings. 

In any case, I think I need more test cases to test the range of swapFee and platformFee. 