### PR TITLE
Upgrade to Istanbul

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” 
 Specific tweaks:
 - Change variable names of LP token `symbol` and `name`.
 - `CREATE2` hash. 
-- `chainId()` OPCODE call replaced with hard-coded value (0x27 or 0x4a)
-- Compiler option changed to `constantinople`
 
 Before deploy:
- - Set desired chainTag 0x27 for testnet, 0x4a for mainnet. Default is testnet.
  - Check CREATE2 hashes using check_create2 script

--- a/uniswap-lib/test/AddressStringUtil.spec.ts
+++ b/uniswap-lib/test/AddressStringUtil.spec.ts
@@ -15,7 +15,7 @@ const example = '0xC257274276a4E539741Ca11b590B9447B26A8051'
 describe('AddressStringUtil', () => {
   const provider = new MockProvider({
     ganacheOptions: {
-      hardfork: 'constantinople',
+      hardfork: 'istanbul',
       mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
       gasLimit: 9999999,
     },

--- a/uniswap-lib/test/Babylonian.spec.ts
+++ b/uniswap-lib/test/Babylonian.spec.ts
@@ -13,7 +13,7 @@ const overrides = {
 describe('Babylonian', () => {
   const provider = new MockProvider({
     ganacheOptions: {
-      hardfork: 'constantinople',
+      hardfork: 'istanbul',
       mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
       gasLimit: 9999999,
     },

--- a/uniswap-lib/test/BitMath.spec.ts
+++ b/uniswap-lib/test/BitMath.spec.ts
@@ -13,7 +13,7 @@ const overrides = {
 describe('BitMath', () => {
   const provider = new MockProvider({
     ganacheOptions: {
-      hardfork: 'constantinople',
+      hardfork: 'istanbul',
       mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
       gasLimit: 9999999,
     },

--- a/uniswap-lib/test/FixedPoint.spec.ts
+++ b/uniswap-lib/test/FixedPoint.spec.ts
@@ -15,7 +15,7 @@ const Q112 = BigNumber.from(2).pow(112)
 describe('FixedPoint', () => {
   const provider = new MockProvider({
     ganacheOptions: {
-      hardfork: 'constantinople',
+      hardfork: 'istanbul',
       mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
       gasLimit: 9999999,
     },

--- a/uniswap-lib/test/FullMath.spec.ts
+++ b/uniswap-lib/test/FullMath.spec.ts
@@ -13,7 +13,7 @@ const overrides = {
 describe('FullMath', () => {
   const provider = new MockProvider({
     ganacheOptions: {
-      hardfork: 'constantinople',
+      hardfork: 'istanbul',
       mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
       gasLimit: 9999999,
     },

--- a/uniswap-lib/test/SafeERC20Namer.spec.ts
+++ b/uniswap-lib/test/SafeERC20Namer.spec.ts
@@ -21,7 +21,7 @@ const fullBytes32Symbol = 'SYMB'.repeat(8).substr(0, 31)
 describe('SafeERC20Namer', () => {
   const provider = new MockProvider({
     ganacheOptions: {
-      hardfork: 'constantinople',
+      hardfork: 'istanbul',
       mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
       gasLimit: 9999999,
     },

--- a/uniswap-lib/test/TransferHelper.spec.ts
+++ b/uniswap-lib/test/TransferHelper.spec.ts
@@ -16,7 +16,7 @@ const overrides = {
 describe('TransferHelper', () => {
   const provider = new MockProvider({
     ganacheOptions: {
-      hardfork: 'constantinople',
+      hardfork: 'istanbul',
       mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
       gasLimit: 9999999,
     },

--- a/uniswap-lib/waffle.json
+++ b/uniswap-lib/waffle.json
@@ -16,7 +16,7 @@
         "": ["ast"]
       }
     },
-    "evmVersion": "constantinople",
+    "evmVersion": "istanbul",
     "optimizer": {
       "enabled": true,
       "runs": 999999

--- a/uniswap-v2-core/.waffle.json
+++ b/uniswap-v2-core/.waffle.json
@@ -15,7 +15,7 @@
         "": ["ast"]
       }
     },
-    "evmVersion": "constantinople",
+    "evmVersion": "istanbul",
     "optimizer": {
       "enabled": true,
       "runs": 999999

--- a/uniswap-v2-core/contracts/VexchangeV2ERC20.sol
+++ b/uniswap-v2-core/contracts/VexchangeV2ERC20.sol
@@ -24,7 +24,7 @@ contract VexchangeV2ERC20 is IVexchangeV2ERC20 {
     constructor() public {
         uint chainId;
         assembly {
-            chainId := 0x27
+            chainId := chainid
         }
         DOMAIN_SEPARATOR = keccak256(
             abi.encode(
@@ -35,6 +35,15 @@ contract VexchangeV2ERC20 is IVexchangeV2ERC20 {
                 address(this)
             )
         );
+    }
+
+    // Convenience access method for test-harness
+    function chainId() external pure returns (uint256) {
+        uint _chainId;
+        assembly {
+            _chainId := chainid
+        }
+        return _chainId;
     }
 
     function _mint(address to, uint value) internal {

--- a/uniswap-v2-core/contracts/interfaces/IVexchangeV2Pair.sol
+++ b/uniswap-v2-core/contracts/interfaces/IVexchangeV2Pair.sol
@@ -4,6 +4,7 @@ interface IVexchangeV2Pair {
     event Approval(address indexed owner, address indexed spender, uint value);
     event Transfer(address indexed from, address indexed to, uint value);
 
+    function chainId() external pure returns (uint256);
     function name() external pure returns (string memory);
     function symbol() external pure returns (string memory);
     function decimals() external pure returns (uint8);

--- a/uniswap-v2-core/test/VexchangeV2Factory.spec.ts
+++ b/uniswap-v2-core/test/VexchangeV2Factory.spec.ts
@@ -18,7 +18,7 @@ const TEST_ADDRESSES: [string, string] = [
 
 describe('VexchangeV2Factory', () => {
   const provider = new MockProvider({
-    hardfork: 'constantinople',
+    hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
     gasLimit: 9999999
   })
@@ -85,7 +85,7 @@ describe('VexchangeV2Factory', () => {
     // Expected init-code (hard coded value is used in dependent modules as a gas optimisation, so also verified here).
     // Note: changing the hard-coded expected init-code value implies you will need to also update the dependency.
     // See dependency @ uniswap-v2-periphery/contracts/libraries/VexchangeV2Library.sol
-    expect(initCode, 'VexchangeV2Pair init-code').to.eq('0x44d7f7cd5dedd2b5caa1510508a9b0aa29ba9a209173e464d90ccc2fdb3ffcdc')
+    expect(initCode, 'VexchangeV2Pair init-code').to.eq('0x597842963dd96a7950f4a0e1fc043055599d6e4e7154f8190d1ff640509e5900')
   })
 
   it('createPair:reverse', async () => {
@@ -97,7 +97,7 @@ describe('VexchangeV2Factory', () => {
     const receipt = await tx.wait()
 
     // Hard-coded gas cost based on current extension
-    expect(receipt.gasUsed).to.eq(3005567)
+    expect(receipt.gasUsed).to.eq(3018852)
   })
 
   it('setPlatformFeeTo', async () => {

--- a/uniswap-v2-core/test/VexchangeV2Pair.spec.ts
+++ b/uniswap-v2-core/test/VexchangeV2Pair.spec.ts
@@ -17,7 +17,7 @@ const overrides = {
 
 describe('VexchangeV2Pair', () => {
   const provider = new MockProvider({
-    hardfork: 'constantinople',
+    hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
     gasLimit: 9999999
   })
@@ -188,7 +188,7 @@ describe('VexchangeV2Pair', () => {
     const receipt = await tx.wait()
 
     // Hard-coded gas cost based on current extension
-    expect(receipt.gasUsed).to.eq(67219)
+    expect(receipt.gasUsed).to.eq(75059)
   })
 
   it('burn', async () => {
@@ -344,7 +344,7 @@ describe('VexchangeV2Pair', () => {
 
     // Gas price seems to be inconsistent for the swap
     expect(receipt.gasUsed).to.satisfy( function(gas: number) {
-      return ((gas==56403) || (gas==97219));
+      return verifyGas( gas, [63043, 97219, 105059], "platformFee off swap gas" );
     })
 
     // Drain the liquidity to verify no fee has been extracted on exit
@@ -391,7 +391,7 @@ describe('VexchangeV2Pair', () => {
     // Gas price seems to be inconsistent for the swap; most likely due to test framework. (TBC)
     // Every ~ 1 in 4 runs will see the higher gas cost.
     expect(receipt.gasUsed).to.satisfy( function(gas: number) {
-      return verifyGas(gas, [56403,97219], "Swap gas cost");
+      return verifyGas(gas, [63043, 105059], "Swap gas cost");
     })
 
     const newToken0Balance = await token0.balanceOf(pair.address)
@@ -405,10 +405,10 @@ describe('VexchangeV2Pair', () => {
     // Gas price seems to be inconsistent for the swap; most likely due to test framework. (TBC)
     // Every ~ 1 in 10 runs will see the higher gas cost.
     expect(burnReceipt.gasUsed, "Check burn op gas cost").to.satisfy( function(gas: number) {
-      return verifyGas( gas, [159865, 119049], "Burn gas cost" );
+      return verifyGas( gas, [135736,177752], "Burn gas cost" );
     })
     
-    // Expected fee @ 1/6 or 16.67% is calculated at 249800449363715 which is a ~0.02% error off the original uniswap.
+    // Expected fee @ 1/6 or 0.1667% is calculated at 249800449363715 which is a ~0.02% error off the original uniswap.
     // (Original uniswap v2 equivalent ==> 249750499251388)
     const expectedPlatformFee: BigNumber = bigNumberify(249800449363715)
 
@@ -428,13 +428,13 @@ describe('VexchangeV2Pair', () => {
     const minInverseVariance: number = targetInverseVariance * 0.95;
     const maxInverseVariance: number = targetInverseVariance * 1.05;
 
-    // Compare 1/6 vexchangeV2 fee, using 1667 bp Vexchange Platform fee: run check to confirm ~ 0.02% variance.
+    // Compare 1/6 vexchangeV2 fee, using 0.1667 Vexchange Platform fee: run check to confirm ~ 0.02% variance.
     const token0ExpBalVexchangeV2: BigNumber = bigNumberify( '249501683697445' )
     const token0ExpBalVexchange: BigNumber = bigNumberify( '249551584034184' )
     const token0Variance: number = token0ExpBalVexchangeV2.div(token0ExpBalVexchange.sub(token0ExpBalVexchangeV2)).toNumber();
     expect(token0Variance, "token 0 variance from uniswap v2 fee" ).to.be.within(minInverseVariance, maxInverseVariance)
 
-    // Compare 1/6 vexchangeV2 fee, using 1667 bp Vexchange Platform fee: run check to confirm ~ 0.02% variance.
+    // Compare 1/6 vexchangeV2 fee, using 0.1667 Vexchange Platform fee: run check to confirm ~ 0.02% variance.
     const token1ExpBalVexchangeV2: BigNumber = bigNumberify( '250000187312969' )
     const token1ExpBalVexchange: BigNumber = bigNumberify( '250050187350431' )
     const token1Variance: number = token1ExpBalVexchangeV2.div(token1ExpBalVexchange.sub(token1ExpBalVexchangeV2)).toNumber();
@@ -764,7 +764,7 @@ describe('VexchangeV2Pair', () => {
     
         // Gas price seems to be inconsistent for the swap
         expect(swapReceipt.gasUsed, "swap gas fee").to.satisfy( function(gas: number) {
-          return verifyGas( gas, [56339, 56403, 97155, 97219 ], "swap gas fee" ); })
+          return verifyGas( gas, [63031, 63043, 105047, 105059], "swap gas fee" ); })
     
         // Calculate the expected platform fee
         const token0PairBalanceAfterSwap = await token0.balanceOf(pair.address);
@@ -785,7 +785,7 @@ describe('VexchangeV2Pair', () => {
     
         // Check the (inconsistent) gas fee
         expect(burnReceipt.gasUsed, "burn gas fee").to.satisfy( 
-          function(gas: number) { return verifyGas( gas, [169239, 128423], "burn gas fee" ); })
+          function(gas: number) { return verifyGas( gas, [145110, 187126], "burn gas fee" ); })
     
         // Check that the fee receiver (account set to platformFeeTo) received the fees
         expect(await pair.balanceOf(other.address), "Fee receiver balance").to.eq( expectedPlatformFee )

--- a/uniswap-v2-periphery/.waffle.json
+++ b/uniswap-v2-periphery/.waffle.json
@@ -15,7 +15,7 @@
         "": ["ast"]
       }
     },
-    "evmVersion": "constantinople",
+    "evmVersion": "istanbul",
     "optimizer": {
       "enabled": true,
       "runs": 999999

--- a/uniswap-v2-periphery/contracts/ext-v2-core/IVexchangeV2Pair.sol
+++ b/uniswap-v2-periphery/contracts/ext-v2-core/IVexchangeV2Pair.sol
@@ -4,6 +4,7 @@ interface IVexchangeV2Pair {
     event Approval(address indexed owner, address indexed spender, uint value);
     event Transfer(address indexed from, address indexed to, uint value);
 
+    function chainId() external pure returns (uint256);
     function name() external pure returns (string memory);
     function symbol() external pure returns (string memory);
     function decimals() external pure returns (uint8);

--- a/uniswap-v2-periphery/contracts/libraries/VexchangeV2Library.sol
+++ b/uniswap-v2-periphery/contracts/libraries/VexchangeV2Library.sol
@@ -23,7 +23,7 @@ library VexchangeV2Library {
                 keccak256(abi.encodePacked(token0, token1)),
 
                 // Updated hard-coded hash for current VexchangeV2Pair
-                hex'44d7f7cd5dedd2b5caa1510508a9b0aa29ba9a209173e464d90ccc2fdb3ffcdc'
+                hex'597842963dd96a7950f4a0e1fc043055599d6e4e7154f8190d1ff640509e5900'
             ))));
     }
     

--- a/uniswap-v2-periphery/contracts/test/DeflatingERC20.sol
+++ b/uniswap-v2-periphery/contracts/test/DeflatingERC20.sol
@@ -23,7 +23,7 @@ contract DeflatingERC20 {
     constructor(uint _totalSupply) public {
         uint chainId;
         assembly {
-            chainId := 0x27
+            chainId := chainid()
         }
         DOMAIN_SEPARATOR = keccak256(
             abi.encode(

--- a/uniswap-v2-periphery/contracts/test/ERC20.sol
+++ b/uniswap-v2-periphery/contracts/test/ERC20.sol
@@ -23,7 +23,7 @@ contract ERC20 {
     constructor(uint _totalSupply) public {
         uint chainId;
         assembly {
-            chainId := 0x27
+            chainId := chainid()
         }
         DOMAIN_SEPARATOR = keccak256(
             abi.encode(

--- a/uniswap-v2-periphery/test/ExampleComputeLiquidityValue.spec.ts
+++ b/uniswap-v2-periphery/test/ExampleComputeLiquidityValue.spec.ts
@@ -16,7 +16,7 @@ const overrides = {
 
 describe('ExampleComputeLiquidityValue', () => {
   const provider = new MockProvider({
-    hardfork: 'constantinople',
+    hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
     gasLimit: 9999999
   })
@@ -251,7 +251,7 @@ describe('ExampleComputeLiquidityValue', () => {
             100,
             expandTo18Decimals(5)
           )
-        ).to.eq('13684')
+        ).to.eq('16084')
       })
 
       it('gas higher price', async () => {
@@ -263,7 +263,7 @@ describe('ExampleComputeLiquidityValue', () => {
             105,
             expandTo18Decimals(5)
           )
-        ).to.eq('14471')
+        ).to.eq('16871')
       })
 
       it('gas lower price', async () => {
@@ -275,7 +275,7 @@ describe('ExampleComputeLiquidityValue', () => {
             95,
             expandTo18Decimals(5)
           )
-        ).to.eq('14516')
+        ).to.eq('16916')
       })
 
       describe('after a swap', () => {
@@ -383,7 +383,7 @@ describe('ExampleComputeLiquidityValue', () => {
             100,
             expandTo18Decimals(5)
           )
-        ).to.eq('17296')
+        ).to.eq('20338')
       })
 
       it('gas higher price', async () => {
@@ -395,7 +395,7 @@ describe('ExampleComputeLiquidityValue', () => {
             105,
             expandTo18Decimals(5)
           )
-        ).to.eq('18879')
+        ).to.eq('21921')
       })
 
       it('gas lower price', async () => {
@@ -407,7 +407,7 @@ describe('ExampleComputeLiquidityValue', () => {
             95,
             expandTo18Decimals(5)
           )
-        ).to.eq('18810')
+        ).to.eq('21852')
       })
 
       describe('after a swap', () => {

--- a/uniswap-v2-periphery/test/ExampleFlashSwap.spec.ts
+++ b/uniswap-v2-periphery/test/ExampleFlashSwap.spec.ts
@@ -18,7 +18,7 @@ const overrides = {
 
 describe('ExampleFlashSwap', () => {
   const provider = new MockProvider({
-    hardfork: 'constantinople',
+    hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
     gasLimit: 9999999
   })

--- a/uniswap-v2-periphery/test/ExampleOracleSimple.spec.ts
+++ b/uniswap-v2-periphery/test/ExampleOracleSimple.spec.ts
@@ -19,7 +19,7 @@ const token1Amount = expandTo18Decimals(10)
 
 describe('ExampleOracleSimple', () => {
   const provider = new MockProvider({
-    hardfork: 'constantinople',
+    hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
     gasLimit: 9999999
   })

--- a/uniswap-v2-periphery/test/ExampleSlidingWindowOracle.spec.ts
+++ b/uniswap-v2-periphery/test/ExampleSlidingWindowOracle.spec.ts
@@ -19,7 +19,7 @@ const defaultToken1Amount = expandTo18Decimals(10)
 
 describe('ExampleSlidingWindowOracle', () => {
   const provider = new MockProvider({
-    hardfork: 'constantinople',
+    hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
     gasLimit: 9999999
   })
@@ -150,14 +150,14 @@ describe('ExampleSlidingWindowOracle', () => {
     it('gas for first update (allocates empty array)', async () => {
       const tx = await slidingWindowOracle.update(token0.address, token1.address, overrides)
       const receipt = await tx.wait()
-      expect(receipt.gasUsed).to.eq('86039')
+      expect(receipt.gasUsed).to.eq('116796')
     }).retries(2) // gas test inconsistent
 
     it('gas for second update in the same period (skips)', async () => {
       await slidingWindowOracle.update(token0.address, token1.address, overrides)
       const tx = await slidingWindowOracle.update(token0.address, token1.address, overrides)
       const receipt = await tx.wait()
-      expect(receipt.gasUsed).to.eq('26062')
+      expect(receipt.gasUsed).to.eq('25574')
     }).retries(2) // gas test inconsistent
 
     it('gas for second update different period (no allocate, no skip)', async () => {
@@ -165,7 +165,7 @@ describe('ExampleSlidingWindowOracle', () => {
       await mineBlock(provider, startTime + 3600)
       const tx = await slidingWindowOracle.update(token0.address, token1.address, overrides)
       const receipt = await tx.wait()
-      expect(receipt.gasUsed).to.eq('93326')
+      expect(receipt.gasUsed).to.eq('94683')
     }).retries(2) // gas test inconsistent
 
     it('second update in one timeslot does not overwrite', async () => {

--- a/uniswap-v2-periphery/test/ExampleSwapToPrice.spec.ts
+++ b/uniswap-v2-periphery/test/ExampleSwapToPrice.spec.ts
@@ -17,7 +17,7 @@ const overrides = {
 
 describe('ExampleSwapToPrice', () => {
   const provider = new MockProvider({
-    hardfork: 'constantinople',
+    hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
     gasLimit: 9999999
   })
@@ -193,7 +193,7 @@ describe('ExampleSwapToPrice', () => {
       )
       const receipt = await tx.wait()
       expect(receipt.gasUsed).to.satisfy( function(gas: number) {
-        return verifyGas( gas, [114513, 155329], "Swap gas cost" )
+        return verifyGas( gas, [123489, 165505], "Swap gas cost" )
       }) // gas test is inconsistent
     })
   })

--- a/uniswap-v2-periphery/test/VexchangeV2Migrator.spec.ts
+++ b/uniswap-v2-periphery/test/VexchangeV2Migrator.spec.ts
@@ -15,7 +15,7 @@ const overrides = {
 
 describe('VexchangeV2Migrator', () => {
   const provider = new MockProvider({
-    hardfork: 'constantinople',
+    hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
     gasLimit: 9999999
   })

--- a/uniswap-v2-periphery/test/VexchangeV2Router01.spec.ts
+++ b/uniswap-v2-periphery/test/VexchangeV2Router01.spec.ts
@@ -22,7 +22,7 @@ enum RouterVersion {
 describe('VexchangeV2Router{01,02}', () => {
   for (const routerVersion of Object.keys(RouterVersion)) {
     const provider = new MockProvider({
-      hardfork: 'constantinople',
+      hardfork: 'istanbul',
       mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
       gasLimit: 9999999
     })
@@ -240,13 +240,14 @@ describe('VexchangeV2Router{01,02}', () => {
 
         const expectedLiquidity = expandTo18Decimals(2)
 
+        const chainId = await pair.chainId()
         const nonce = await pair.nonces(wallet.address)
         const digest = await getApprovalDigest(
           pair,
           { owner: wallet.address, spender: router.address, value: expectedLiquidity.sub(MINIMUM_LIQUIDITY) },
           nonce,
           MaxUint256,
-          0x27
+          chainId
         )
 
         const { v, r, s } = ecsign(Buffer.from(digest.slice(2), 'hex'), Buffer.from(wallet.privateKey.slice(2), 'hex'))
@@ -277,13 +278,14 @@ describe('VexchangeV2Router{01,02}', () => {
 
         const expectedLiquidity = expandTo18Decimals(2)
 
+        const chainId = await pair.chainId()
         const nonce = await VVETPair.nonces(wallet.address)
         const digest = await getApprovalDigest(
           VVETPair,
           { owner: wallet.address, spender: router.address, value: expectedLiquidity.sub(MINIMUM_LIQUIDITY) },
           nonce,
           MaxUint256,
-          0x27
+          chainId
         )
 
         const { v, r, s } = ecsign(Buffer.from(digest.slice(2), 'hex'), Buffer.from(wallet.privateKey.slice(2), 'hex'))
@@ -370,8 +372,8 @@ describe('VexchangeV2Router{01,02}', () => {
           const receipt = await tx.wait()
           expect(receipt.gasUsed).to.eq(
             {
-              [RouterVersion.VexchangeV2Router01]: 99751,
-              [RouterVersion.VexchangeV2Router02]: 99773
+              [RouterVersion.VexchangeV2Router01]: 106943,
+              [RouterVersion.VexchangeV2Router02]: 106965
             }[routerVersion as RouterVersion]
           )
         }).retries(3)
@@ -519,10 +521,10 @@ describe('VexchangeV2Router{01,02}', () => {
           const receipt = await tx.wait()
           expect(receipt.gasUsed).to.satisfy( function(gas: number) {
             if (routerVersion == RouterVersion.VexchangeV2Router01) {
-              return verifyGas(gas, [104522, 134522], "swapExactVETForTokens Router01");
+              return verifyGas(gas, [113826, 143826], "swapExactVETForTokens Router01");
             }
             else if (routerVersion == RouterVersion.VexchangeV2Router02) {
-              return verifyGas(gas, [104545, 134545], "swapExactVETForTokens Router02");
+              return verifyGas(gas, [113849, 143849], "swapExactVETForTokens Router02");
             }
           })
         })

--- a/uniswap-v2-periphery/test/VexchangeV2Router02.spec.ts
+++ b/uniswap-v2-periphery/test/VexchangeV2Router02.spec.ts
@@ -19,7 +19,7 @@ const overrides = {
 
 describe('VexchangeV2Router02', () => {
   const provider = new MockProvider({
-    hardfork: 'constantinople',
+    hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
     gasLimit: 9999999
   })
@@ -123,7 +123,7 @@ describe('VexchangeV2Router02', () => {
 
 describe('fee-on-transfer tokens', () => {
   const provider = new MockProvider({
-    hardfork: 'constantinople',
+    hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
     gasLimit: 9999999
   })
@@ -192,14 +192,15 @@ describe('fee-on-transfer tokens', () => {
     await addLiquidity(DTTAmount, VETAmount)
 
     const expectedLiquidity = expandTo18Decimals(2)
-
+    
+    const chainId = await pair.chainId()
     const nonce = await pair.nonces(wallet.address)
     const digest = await getApprovalDigest(
       pair,
       { owner: wallet.address, spender: router.address, value: expectedLiquidity.sub(MINIMUM_LIQUIDITY) },
       nonce,
       MaxUint256,
-      0x27
+      chainId
     )
     const { v, r, s } = ecsign(Buffer.from(digest.slice(2), 'hex'), Buffer.from(wallet.privateKey.slice(2), 'hex'))
 
@@ -311,7 +312,7 @@ describe('fee-on-transfer tokens', () => {
 
 describe('fee-on-transfer tokens: reloaded', () => {
   const provider = new MockProvider({
-    hardfork: 'constantinople',
+    hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
     gasLimit: 9999999
   })


### PR DESCRIPTION
This is the PR for upgrading to Instanbul. Note that the different solidity use of chainid vs chainId() is due to the version of solidity used by core vs periphery. (which we decided not to change)

With this  use of chainId, for automatic alignment of chain-id in the contracts, the only complication was that there was no straight forward way i found to set the chain-id in the test environment (it is 0x01) or align the test-code chainId with the chainId used by the chain simulation.

Obviously with the contracts using the chainid/chainId() changes, they pick up whatever the EVM is using (0x01 now) and so we need to align certain tests with that. I did find `provider.network.chainId` in the ethers components, but it was not correctly initialised.

To resolve this, i add an external/pure function to the ERC20 contracts in play, to retrieve the network's chainId. 

This is not ideal, and there may be a better solution - but it works to give us a means for our test code to align with the actual chainId being used (whatever it is) ... so the whole project, including test-code is at least no longer dependent on a given chainId.